### PR TITLE
RelayHandler: add lazy support

### DIFF
--- a/connection.js
+++ b/connection.js
@@ -97,11 +97,10 @@ TChannelConnection.prototype.setLazyHandling = function setLazyHandling(enabled)
     // moves wholly into a `self.handler.setLazyHandling(bool)`
     if (enabled && self.mach.chunkRW !== v2.LazyFrame.RW) {
         self.mach.chunkRW = v2.LazyFrame.RW;
-        self.handler.useLazyFrames(enabled);
     } else if (!enabled && self.mach.chunkRW !== v2.Frame.RW) {
         self.mach.chunkRW = v2.Frame.RW;
-        self.handler.useLazyFrames(enabled);
     }
+    self.handler.useLazyFrames(enabled);
 };
 
 TChannelConnection.prototype.setupSocket = function setupSocket() {

--- a/relay_handler.js
+++ b/relay_handler.js
@@ -294,23 +294,23 @@ RelayRequest.prototype.logError = function relayRequestLogError(err, codeName) {
 function logError(logger, err, codeName, extendLogInfo) {
     var level = errors.logLevel(err, codeName);
 
-    var logOptions = extendLogInfo({
+    var info = extendLogInfo({
         error: err,
         isErrorFrame: err.isErrorFrame
     });
 
     if (err.isErrorFrame) {
         if (level === 'warn') {
-            logger.warn('forwarding error frame', logOptions);
+            logger.warn('forwarding error frame', info);
         } else if (level === 'info') {
-            logger.info('forwarding expected error frame', logOptions);
+            logger.info('forwarding expected error frame', info);
         }
     } else if (level === 'error') {
-        logger.error('unexpected error while forwarding', logOptions);
+        logger.error('unexpected error while forwarding', info);
     } else if (level === 'warn') {
-        logger.warn('error while forwarding', logOptions);
+        logger.warn('error while forwarding', info);
     } else if (level === 'info') {
-        logger.info('expected error while forwarding', logOptions);
+        logger.info('expected error while forwarding', info);
     }
 }
 

--- a/relay_handler.js
+++ b/relay_handler.js
@@ -30,6 +30,7 @@ function RelayHandler(channel, circuits) {
     var self = this;
     self.channel = channel;
     self.circuits = circuits || null;
+    self.logger = self.channel.logger;
 }
 
 RelayHandler.prototype.type = 'tchannel.relay-handler';
@@ -59,7 +60,7 @@ RelayHandler.prototype._handleRequest = function _handleRequest(req, buildRes) {
 
     // TODO add this back in a performant way ??
     // if (rereq) {
-    //     self.channel.logger.error('relay request already exists for incoming request', {
+    //     self.logger.error('relay request already exists for incoming request', {
     //         inReqId: req.id,
     //         priorInResId: rereq.inres && rereq.inres.id,
     //         priorOutResId: rereq.outres && rereq.outres.id,
@@ -80,7 +81,7 @@ RelayHandler.prototype._handleRequest = function _handleRequest(req, buildRes) {
         // TODO: allow for customization of this message so hyperbahn can
         // augment it with things like "at entry node", "at exit node", etc
         buildRes().sendError('Declined', 'no peer available for request');
-        self.channel.logger.warn('no relay peer available', req.extendLogInfo({}));
+        self.logger.warn('no relay peer available', req.extendLogInfo({}));
         return;
     }
 

--- a/relay_handler.js
+++ b/relay_handler.js
@@ -413,6 +413,7 @@ function checkTimeout() {
         if (elapsed > self.timeout) {
             self.timedOut = true;
             // TODO: send cancel?
+            // TODO: lighter interface that doesn't create an error to send a frame
             self.inreq.onError(errors.RequestTimeoutError({
                 id: self.id,
                 start: self.start,

--- a/relay_handler.js
+++ b/relay_handler.js
@@ -39,6 +39,8 @@ RelayHandler.prototype.type = 'tchannel.relay-handler';
 RelayHandler.prototype.handleLazily = function handleLazily(conn, reqFrame) {
     var self = this;
 
+    // TODO: provide a by-service-name config hook?
+
     var rereq = new LazyRelayInReq(conn, reqFrame);
     var err = rereq.initRead();
     if (err) {

--- a/relay_handler.js
+++ b/relay_handler.js
@@ -21,6 +21,7 @@
 'use strict';
 
 var errors = require('./errors');
+var v2 = require('./v2');
 
 RelayHandler.RelayRequest = RelayRequest;
 
@@ -34,6 +35,35 @@ function RelayHandler(channel, circuits) {
 }
 
 RelayHandler.prototype.type = 'tchannel.relay-handler';
+
+RelayHandler.prototype.handleLazily = function handleLazily(conn, reqFrame) {
+    var self = this;
+
+    var rereq = new LazyRelayInReq(conn, reqFrame);
+    var err = rereq.initRead();
+    if (err) {
+        rereq.onError(err);
+        return true;
+    }
+
+    rereq.peer = self.channel.peers.choosePeer(null);
+    if (!rereq.peer) {
+        rereq.sendErrorFrame('Declined', 'no peer available for request');
+        self.logger.warn('no relay peer available', rereq.extendLogInfo({}));
+        return true;
+    }
+
+    if (self.circuits) {
+        self.logger.warn('circuit breaking for lazy realying isn\'t implemented', {
+            serviceName: self.channel.serviceName
+        });
+        return false;
+    }
+
+    conn.ops.addInReq(rereq);
+    rereq.createOutRequest();
+    return true;
+};
 
 RelayHandler.prototype.handleRequest = function handleRequest(req, buildRes) {
     var self = this;
@@ -89,6 +119,365 @@ RelayHandler.prototype._handleRequest = function _handleRequest(req, buildRes) {
     rereq.createOutRequest();
 };
 
+// TODO: lazy reqs
+// - #onTimeout
+// - audit #extendLogInfo vs regular reqs
+
+function LazyRelayInReq(conn, reqFrame) {
+    var self = this;
+
+    self.start = conn.timers.now();
+    self.remoteAddr = conn.remoteName;
+    self.conn = conn;
+    self.logger = conn.logger;
+    self.peer = null;
+    self.outreq = null;
+    self.reqFrame = reqFrame;
+    self.id = self.reqFrame.id;
+    self.serviceName = '';
+    self.callerName = '';
+    self.timeout = 0;
+    self.timedOut = false;
+    self.alive = true;
+
+    self.boundExtendLogInfo = extendLogInfo;
+    self.boundOnIdentified = onIdentified;
+
+    function extendLogInfo(info) {
+        return self.extendLogInfo(info);
+    }
+
+    function onIdentified(err) {
+        if (err) {
+            self.onError(err);
+        } else {
+            self.onIdentified();
+        }
+    }
+}
+
+LazyRelayInReq.prototype.type = 'tchannel.lazy.incoming-request';
+
+LazyRelayInReq.prototype.initRead =
+function initRead() {
+    var self = this;
+
+    var res = self.reqFrame.bodyRW.lazy.readTTL(self.reqFrame);
+    if (res.err) {
+        // TODO: wrap? protocol read error?
+        return res.err;
+    }
+    self.timeout = res.value;
+
+    res = self.reqFrame.bodyRW.lazy.readService(self.reqFrame);
+    if (res.err) {
+        // TODO: wrap? protocol read error?
+        return res.err;
+    }
+    self.serviceName = res.value;
+
+    // TODO: lazy read self.callerName
+
+    return null;
+};
+
+LazyRelayInReq.prototype.extendLogInfo =
+function extendLogInfo(info) {
+    var self = this;
+
+    if (self.outreq) {
+        info = self.outreq._extendLogInfo(info);
+    }
+
+    info = self._extendLogInfo(info);
+
+    return info;
+};
+
+LazyRelayInReq.prototype._extendLogInfo =
+function _extendLogInfo(info) {
+    var self = this;
+
+    info.requestType = self.type;
+    info.inRemoteAddr = self.remoteAddr;
+    info.inRequestId = self.id;
+    info.serviceName = self.serviceName;
+
+    // TODO: why not full peer.extendLogInfo
+    if (self.peer) {
+        info.hostPort = self.peer.hostPort;
+    }
+
+    return info;
+};
+
+LazyRelayInReq.prototype.logError =
+function relayRequestlogError(err, codeName) {
+    var self = this;
+    logError(self.conn.logger, err, codeName, function extendLogInfo(info) {
+        return self.extendLogInfo(info);
+    });
+};
+
+LazyRelayInReq.prototype.checkTimeout =
+function checkTimeout() {
+    var self = this;
+    if (!self.timedOut) {
+        var elapsed = self.conn.timers.now() - self.start;
+        if (elapsed > self.timeout) {
+            self.timedOut = true;
+            // TODO: cancel any outreq?
+            self.onError(errors.RequestTimeoutError({
+                id: self.id,
+                start: self.start,
+                elapsed: elapsed,
+                timeout: self.timeout
+            }));
+        }
+    }
+    return self.timedOut;
+};
+
+LazyRelayInReq.prototype.createOutRequest =
+function createOutRequest() {
+    var self = this;
+
+    if (self.outreq) {
+        self.conn.logger.warn('relay request already started', self.extendLogInfo({}));
+        return;
+    }
+
+    self.peer.waitForIdentified(self.boundOnIdentified);
+};
+
+LazyRelayInReq.prototype.onIdentified =
+function onIdentified(err) {
+    var self = this;
+
+    if (err) {
+        self.onError(err);
+        return;
+    }
+
+    var conn = chooseRelayPeerConnection(self.peer);
+    if (!conn.remoteName) {
+        // we get the problem
+        self.logger.warn('onIdentified called on unidentified connection', self.extendLogInfo({}));
+    }
+    if (conn.closing) {
+        // most likely
+        self.logger.warn('onIdentified called on closing connection', self.extendLogInfo({}));
+    }
+
+    self.outreq = new LazyRelayOutReq(conn, self);
+
+    var ttl = self.updateTTL(self.outreq.start);
+    if (!ttl || ttl < 0) {
+        // error or timeout, observability handled already by #updateTTL
+        return;
+    }
+
+    self.outreq.timeout = ttl;
+    conn.ops.addOutReq(self.outreq);
+    self.handleFrameLazily(self.reqFrame);
+    self.reqFrame = null;
+};
+
+LazyRelayInReq.prototype.updateTTL =
+function updateTTL(now) {
+    var self = this;
+
+    var elapsed = now - self.start;
+    var timeout = self.timeout - elapsed;
+    if (timeout <= 0) {
+        self.sendErrorFrame('Timeout', 'relay ttl expired');
+        // TODO: log/stat
+        return timeout;
+    }
+
+    var res = self.reqFrame.bodyRW.lazy.writeTTL(timeout, self.reqFrame);
+    if (res.err) {
+        // TODO: wrap? protocol write error?
+        self.onError(res.err);
+        return NaN;
+    }
+
+    return timeout;
+};
+
+LazyRelayInReq.prototype.onError =
+function onError(err) {
+    var self = this;
+
+    if (!self.alive) {
+        self.logger.warn('dropping error from dead relay request', self.extendLogInfo({
+            error: err
+        }));
+        return;
+    }
+
+    self.alive = false;
+    var codeName = errors.classify(err) || 'UnexpectedError';
+    self.sendErrorFrame(codeName, err.message);
+    logError(self.conn.logger, err, codeName, self.boundExtendLogInfo);
+    // TODO: stat in some cases, e.g. declined / peer not available
+    self.conn.ops.popInReq(self.id, self.extendLogInfo({
+        info: 'lazy relay request error',
+        relayDirection: 'in'
+    }));
+};
+
+LazyRelayInReq.prototype.sendErrorFrame =
+function sendErrorFrame(codeName, message) {
+    var self = this;
+    self.conn.sendLazyErrorFrame(self.reqFrame, codeName, message);
+};
+
+LazyRelayInReq.prototype.handleFrameLazily =
+function handleFrameLazily(frame) {
+    // frame.type will be one of:
+    // - v2.Types.CallRequest
+    // - v2.Types.CallRequestCont
+    var self = this;
+
+    if (!self.alive) {
+        self.logger.warn('dropping frame from dead relay request', self.extendLogInfo({}));
+        return;
+    }
+
+    frame.setId(self.outreq.id);
+    self.outreq.conn.socket.write(frame.buffer);
+    if (frame.bodyRW.lazy.isFrameTerminal(frame)) {
+        self.alive = false;
+        self.conn.ops.popInReq(self.id, self.extendLogInfo({
+            info: 'lazy relay request done',
+            relayDirection: 'in'
+        }));
+    }
+};
+
+function LazyRelayOutReq(conn, inreq) {
+    var self = this;
+
+    self.start = conn.timers.now();
+    self.remoetAddr = conn.remoteName;
+    self.conn = conn;
+    self.logger = conn.logger;
+    self.inreq = inreq;
+    self.id = self.conn.nextFrameId();
+    self.serviceName = self.inreq.serviceName;
+    self.callerName = self.inreq.callerName;
+    self.timeout = 0;
+    self.timedOut = false;
+}
+
+LazyRelayOutReq.prototype.type = 'tchannel.lazy.outgoing-request';
+
+LazyRelayOutReq.prototype.extendLogInfo =
+function extendLogInfo(info) {
+    var self = this;
+
+    if (self.inreq) {
+        info = self.inreq._extendLogInfo(info);
+    }
+
+    info = self._extendLogInfo(info);
+
+    return info;
+};
+
+LazyRelayOutReq.prototype._extendLogInfo =
+function _extendLogInfo(info) {
+    var self = this;
+
+    info.requestType = self.type;
+    info.outRequestAddr = self.remoteAddr;
+    info.outRequestId = self.id;
+
+    return info;
+};
+
+LazyRelayOutReq.prototype.logError =
+function relayRequestlogError(err, codeName) {
+    var self = this;
+    logError(self.conn.logger, err, codeName, function extendLogInfo(info) {
+        return self.inreq.extendLogInfo(info);
+    });
+};
+
+LazyRelayOutReq.prototype.checkTimeout =
+function checkTimeout() {
+    var self = this;
+    if (!self.timedOut) {
+        var elapsed = self.conn.timers.now() - self.start;
+        if (elapsed > self.timeout) {
+            self.timedOut = true;
+            // TODO: send cancel?
+            self.inreq.onError(errors.RequestTimeoutError({
+                id: self.id,
+                start: self.start,
+                elapsed: elapsed,
+                timeout: self.timeout
+            }));
+        }
+    }
+    return self.timedOut;
+};
+
+LazyRelayOutReq.prototype.handleFrameLazily =
+function handleFrameLazily(frame) {
+    // frame.type will be one of:
+    // - v2.Types.CallResponse
+    // - v2.Types.CallResponseCont
+    // - v2.Types.ErrorResponse
+    var self = this;
+
+    if (frame.type === v2.Types.ErrorResponse) {
+        self.logForwardedError(frame);
+    }
+
+    frame.setId(self.inreq.id);
+    self.inreq.conn.socket.write(frame.buffer);
+    if (frame.bodyRW.lazy.isFrameTerminal(frame)) {
+        self.conn.ops.popOutReq(self.id, self.extendLogInfo({
+            info: 'lazy relay request done',
+            relayDirection: 'out'
+        }));
+    }
+};
+
+LazyRelayOutReq.prototype.logForwardedError =
+function logForwardedError(errFrame) {
+    var self = this;
+
+    var res = errFrame.bodyRW.lazy.readCode(errFrame);
+    if (res.err) {
+        self.logger.error('failed to read error frame code', self.extendLogInfo({
+            error: res.err
+        }));
+        return;
+    }
+    var code = res.value;
+
+    res = errFrame.bodyRW.lazy.readMessage(errFrame);
+    if (res.err) {
+        self.logger.error('failed to read error frame message', self.extendLogInfo({
+            error: res.err
+        }));
+        return;
+    }
+    var message = res.value;
+
+    // TODO: thinner logErrorFrame that doesn't need to instantiate an error
+    // just to log an error frame
+    var codeErrorType = v2.ErrorResponse.CodeErrors[code];
+    var err = new codeErrorType({
+        originalId: errFrame.id,
+        message: message
+    });
+    self.logError(err, errors.classify(err) || 'UnexpectedError');
+};
+
 function RelayRequest(channel, peer, inreq, buildRes) {
     var self = this;
 
@@ -128,11 +517,7 @@ RelayRequest.prototype.createOutRequest = function createOutRequest() {
     var self = this;
 
     if (self.outreq) {
-        self.logger.warn('relay request already started', {
-            // TODO: better context
-            remoteAddr: self.inreq.remoteAddr,
-            id: self.inreq.id
-        });
+        self.logger.warn('relay request already started', self.extendLogInfo({}));
         return;
     }
 
@@ -195,13 +580,10 @@ RelayRequest.prototype.onIdentified = function onIdentified() {
 RelayRequest.prototype.createOutResponse = function createOutResponse(options) {
     var self = this;
     if (self.outres) {
-        self.logger.warn('relay request already responded', {
-            // TODO: better context
-            remoteAddr: self.inreq.remoteAddr,
-            id: self.inreq.id,
-            options: options,
-            error: self.error
-        });
+        self.logger.warn('relay request already responded', self.extendLogInfo({
+            error: self.error,
+            options: options // TODO: seems like a Bad Idea ™
+        }));
         return null;
     }
 
@@ -258,15 +640,15 @@ RelayRequest.prototype.onError = function onError(err) {
     var self = this;
 
     if (self.error) {
-        self.logger.warn('Unexpected double onError', {
-            remoteAddr: self.inreq.remoteAddr,
-            serviceName: self.inreq.serviceName,
-            endpoint: self.inreq.endpoint,
-            callerName: self.inreq.headers.cn,
-
-            oldError: self.error,
-            error: err
-        });
+        // TODO: verify
+        // remoteAddr: self.inreq.remoteAddr,
+        // serviceName: self.inreq.serviceName,
+        // endpoint: self.inreq.endpoint,
+        // callerName: self.inreq.callerName,
+        self.logger.warn('Unexpected double onError', self.inreq.extendLogInfo({
+            error: err,
+            oldError: self.error
+        }));
     }
     self.error = err;
 
@@ -280,6 +662,9 @@ RelayRequest.prototype.onError = function onError(err) {
 RelayRequest.prototype.extendLogInfo = function extendLogInfo(info) {
     var self = this;
 
+    // XXX does inreq give:
+    // info.remoteAddr = self.inreq.remoteAddr;
+    // info.id = self.inreq.id;
     info.outRemoteAddr = self.outreq && self.outreq.remoteAddr;
     info = self.inreq.extendLogInfo(info);
 

--- a/test/index.js
+++ b/test/index.js
@@ -28,6 +28,7 @@ require('./timeouts.js');
 require('./send.js');
 require('./retry.js');
 require('./relay.js');
+require('./relay_lazy.js');
 require('./relay-stats.js');
 require('./streaming.js');
 require('./streaming_bisect.js');

--- a/test/relay_lazy.js
+++ b/test/relay_lazy.js
@@ -1,0 +1,273 @@
+// Copyright (c) 2015 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+'use strict';
+
+var allocCluster = require('./lib/alloc-cluster');
+var TChannel = require('../channel');
+var RelayHandler = require('../relay_handler');
+
+allocCluster.test('send lazy relay requests', {
+    numPeers: 2
+}, function t(cluster, assert) {
+    var one = cluster.channels[0];
+    var two = cluster.channels[1];
+
+    one.setLazyHandling(true);
+    var oneToTwo = one.makeSubChannel({
+        serviceName: 'two',
+        peers: [two.hostPort]
+    });
+    oneToTwo.handler = new RelayHandler(oneToTwo);
+    oneToTwo.handler.handleRequest = failWrap(
+         oneToTwo.handler.handleRequest,
+         assert, 'handle requests eagerly');
+
+    var twoSvc = two.makeSubChannel({
+        serviceName: 'two'
+    });
+    twoSvc.register('echo', echo);
+
+    var client = TChannel({
+        logger: one.logger,
+        timeoutFuzz: 0
+    });
+    var twoClient = client.makeSubChannel({
+        serviceName: 'two',
+        peers: [one.hostPort],
+        requestDefaults: {
+            serviceName: 'two',
+            headers: {
+                as: 'raw',
+                cn: 'wat'
+            }
+        }
+    });
+
+    twoClient.request({
+        hasNoParent: true
+    }).send('echo', 'foo', 'bar', function done(err, res, arg2, arg3) {
+        assert.ifError(err, 'no unexpected error');
+        assert.equal(String(arg2), 'foo', 'expected arg2');
+        assert.equal(String(arg3), 'bar', 'expected arg3');
+
+        client.close();
+        assert.end();
+    });
+});
+
+allocCluster.test('send relay with tiny timeout', {
+    numPeers: 2
+}, function t(cluster, assert) {
+    var one = cluster.channels[0];
+    var two = cluster.channels[1];
+
+    one.setLazyHandling(true);
+    var oneToTwo = one.makeSubChannel({
+        serviceName: 'two',
+        peers: [two.hostPort]
+    });
+    oneToTwo.handler = new RelayHandler(oneToTwo);
+    oneToTwo.handler.handleRequest = failWrap(
+         oneToTwo.handler.handleRequest,
+         assert, 'handle requests eagerly');
+
+    var twoSvc = two.makeSubChannel({
+        serviceName: 'two'
+    });
+    twoSvc.register('echo', echo);
+
+    var client = TChannel({
+        logger: one.logger,
+        timeoutFuzz: 0
+    });
+    var twoClient = client.makeSubChannel({
+        serviceName: 'two',
+        peers: [one.hostPort],
+        requestDefaults: {
+            serviceName: 'two',
+            headers: {
+                as: 'raw',
+                cn: 'wat'
+            }
+        }
+    });
+
+    twoClient.waitForIdentified({
+        host: one.hostPort
+    }, onIdentified);
+
+    function onIdentified(err1) {
+        assert.ifError(err1);
+
+        twoClient.request({
+            hasNoParent: true,
+            host: one.hostPort,
+            timeout: 15
+        }).send('echo', 'foo', 'bar', function done(err2, res, arg2, arg3) {
+            assert.ifError(err2, 'no unexpected error');
+            assert.equal(String(arg2), 'foo', 'expected arg2');
+            assert.equal(String(arg3), 'bar', 'expected arg3');
+
+            client.close();
+            assert.end();
+        });
+    }
+});
+
+allocCluster.test('relay respects ttl', {
+    numPeers: 3
+}, function t(cluster, assert) {
+    var relay = cluster.channels[0];
+    var source = cluster.channels[1];
+    var dest = cluster.channels[2];
+
+    relay.setLazyHandling(true);
+    var relayChan = relay.makeSubChannel({
+        serviceName: 'dest',
+        peers: [dest.hostPort]
+    });
+    relayChan.handler = new RelayHandler(relayChan);
+    relayChan.handler.handleRequest = failWrap(
+         relayChan.handler.handleRequest,
+         assert, 'handle requests eagerly');
+
+    var destChan = dest.makeSubChannel({
+        serviceName: 'dest'
+    });
+    destChan.register('echoTTL', function echoTTL(req, res) {
+        res.headers.as = 'raw';
+        res.sendOk(null, String(req.timeout));
+    });
+
+    var sourceChan = source.makeSubChannel({
+        serviceName: 'dest',
+        peers: [relay.hostPort],
+        requestDefaults: {
+            headers: {
+                as: 'raw',
+                cn: 'wat'
+            }
+        }
+    });
+
+    sourceChan.request({
+        serviceName: 'dest',
+        hasNoParent: true,
+        timeout: 250
+    }).send('echoTTL', null, null, onResponse);
+
+    function onResponse(err, res, arg2, arg3) {
+        assert.ifError(err);
+        assert.ok(res.ok);
+
+        var ttl = Number(String(arg3));
+        assert.ok(ttl >= 200 && ttl <= 250);
+
+        assert.end();
+    }
+});
+
+allocCluster.test('relay an error frame', {
+    numPeers: 4
+}, function t(cluster, assert) {
+    cluster.logger.whitelist('warn', 'forwarding error frame');
+
+    var one = cluster.channels[0];
+    var two = cluster.channels[1];
+    var three = cluster.channels[2];
+    var four = cluster.channels[3];
+
+    one.setLazyHandling(true);
+    var oneToTwo = one.makeSubChannel({
+        serviceName: 'two',
+        peers: [two.hostPort, three.hostPort]
+    });
+    oneToTwo.handler = new RelayHandler(oneToTwo);
+    oneToTwo.handler.handleRequest = failWrap(
+         oneToTwo.handler.handleRequest,
+         assert, 'handle requests eagerly');
+
+    four.setLazyHandling(true);
+    var fourToTwo = four.makeSubChannel({
+        serviceName: 'two',
+        peers: [two.hostPort, three.hostPort]
+    });
+    fourToTwo.handler = new RelayHandler(fourToTwo);
+    fourToTwo.handler.handleRequest = failWrap(
+         fourToTwo.handler.handleRequest,
+         assert, 'handle requests eagerly');
+
+    var twoSvc2 = three.makeSubChannel({
+        serviceName: 'two'
+    });
+    twoSvc2.register('decline', declineError);
+
+    var twoSvc = two.makeSubChannel({
+        serviceName: 'two'
+    });
+    twoSvc.register('decline', declineError);
+
+    var client = TChannel({
+        logger: one.logger,
+        timeoutFuzz: 0
+    });
+    var twoClient = client.makeSubChannel({
+        serviceName: 'two',
+        peers: [one.hostPort, four.hostPort],
+        requestDefaults: {
+            serviceName: 'two',
+            headers: {
+                as: 'raw',
+                cn: 'wat'
+            }
+        }
+    });
+
+    twoClient.request({
+        hasNoParent: true,
+        headers: {
+            as: 'raw',
+            cn: 'wat'
+        }
+    }).send('decline', 'foo', 'bar', function done(err, res, arg2, arg3) {
+        assert.equal(err.type, 'tchannel.declined', 'expected declined error');
+
+        assert.ok(cluster.logger.items().length >= 1, 'expected some logs');
+        client.close();
+        assert.end();
+    });
+
+    function declineError(req, res, arg2, arg3) {
+        res.sendError('Declined', 'lul');
+    }
+});
+
+function echo(req, res, arg2, arg3) {
+    res.headers.as = 'raw';
+    res.sendOk(arg2, arg3);
+}
+
+function failWrap(method, assert, desc) {
+    return function failWrapper() {
+        assert.fail('should not ' + desc);
+        method.apply(this, arguments);
+    };
+}


### PR DESCRIPTION
Passing a lazy-ported copy of tests/relay with only one logging assertion elided.

r @kriskowal @Raynos 