### PR TITLE
Indirect access to cn header thru req.callerName

### DIFF
--- a/connection_base.js
+++ b/connection_base.js
@@ -196,7 +196,7 @@ TChannelConnectionBase.prototype.runHandler = function runHandler(req) {
         'counter',
         1,
         new stat.InboundCallsRecvdTags(
-            req.headers.cn,
+            req.callerName,
             req.serviceName,
             req.endpoint
         )

--- a/in_request.js
+++ b/in_request.js
@@ -39,6 +39,7 @@ function TChannelInRequest(id, options) {
     self.timeout = options.timeout || 0;
     self.tracing = options.tracing || null;
     self.serviceName = options.serviceName || '';
+    self.callerName = options.headers && options.headers.cn || '';
     self.headers = options.headers || {};
     self.checksum = options.checksum || null;
     self.retryFlags = options.retryFlags || null;
@@ -83,7 +84,7 @@ TChannelInRequest.prototype.extendLogInfo = function extendLogInfo(info) {
     info.requestRemoteAddr = self.remoteAddr;
     info.socketRemoteAddr = self.connection.socketRemoteAddr;
     info.serviceName = self.serviceName;
-    info.callerName = self.headers.cn;
+    info.callerName = self.callerName;
     info.requestErr = self.err;
 
     if (self.endpoint !== null) {
@@ -112,7 +113,7 @@ TChannelInRequest.prototype.setupTracing = function setupTracing(options) {
         name: '' // fill this in later
     });
 
-    self.span.annotateBinary('cn', self.headers.cn);
+    self.span.annotateBinary('cn', self.callerName);
     self.span.annotateBinary('as', self.headers.as);
     if (self.connection) {
         self.span.annotateBinary('src', self.connection.remoteName);

--- a/operations.js
+++ b/operations.js
@@ -79,7 +79,7 @@ function OperationTombstone(operations, id, time, req) {
     self.timeHeapHandle = null;
     self.destroyed = false;
     self.serviceName = req.serviceName;
-    self.callerName = req.headers.cn;
+    self.callerName = req.callerName;
     self.endpoint = req.endpoint;
 }
 
@@ -282,7 +282,7 @@ Operations.prototype.popOutReq = function popOutReq(id, context) {
             serviceName: req.serviceName,
             endpoint: req.endpoint,
             socketRemoteAddr: req.remoteAddr,
-            callerName: req.headers.cn
+            callerName: req.callerName
         });
     }
 

--- a/out_request.js
+++ b/out_request.js
@@ -56,6 +56,7 @@ function TChannelOutRequest(id, options) {
     self.timeout = options.timeout || 0;
     self.tracing = options.tracing || null;
     self.serviceName = options.serviceName || '';
+    self.callerName = options.headers && options.headers.cn || '';
     self.headers = options.headers || {};
     self.checksumType = options.checksumType || 0;
     self.checksum = options.checksum || null;
@@ -133,7 +134,7 @@ function emitPerAttemptErrorStat(err) {
     if (err.isErrorFrame) {
         self.channel.outboundCallsPerAttemptSystemErrorsStat.increment(1, {
             'target-service': self.serviceName,
-            'service': self.headers.cn,
+            'service': self.callerName,
             // TODO should always be buffer
             'target-endpoint': self.endpoint,
             'type': err.codeName,
@@ -142,7 +143,7 @@ function emitPerAttemptErrorStat(err) {
     } else {
         self.channel.outboundCallsPerAttemptOperationalErrorsStat.increment(1, {
             'target-service': self.serviceName,
-            'service': self.headers.cn,
+            'service': self.callerName,
             // TODO should always be buffer
             'target-endpoint': self.endpoint,
             'type': err.type || 'unknown',
@@ -158,7 +159,7 @@ function emitErrorStat(err) {
     if (err.isErrorFrame) {
         self.channel.outboundCallsSystemErrorsStat.increment(1, {
             'target-service': self.serviceName,
-            'service': self.headers.cn,
+            'service': self.callerName,
             // TODO should always be buffer
             'target-endpoint': self.endpoint,
             'type': err.codeName
@@ -166,7 +167,7 @@ function emitErrorStat(err) {
     } else {
         self.channel.outboundCallsOperationalErrorsStat.increment(1, {
             'target-service': self.serviceName,
-            'service': self.headers.cn,
+            'service': self.callerName,
             // TODO should always be buffer
             'target-endpoint': self.endpoint,
             'type': err.type || 'unknown'
@@ -187,7 +188,7 @@ function emitResponseStat(res) {
             1,
             new stat.OutboundCallsAppErrorsTags(
                 self.serviceName,
-                self.headers.cn,
+                self.callerName,
                 self.endpoint,
                 'unknown'
             )
@@ -206,7 +207,7 @@ function emitPerAttemptResponseStat(res) {
             1,
             new stat.OutboundCallsPerAttemptAppErrorsTags(
                 self.serviceName,
-                self.headers.cn,
+                self.callerName,
                 self.endpoint,
                 'unknown',
                 self.retryCount
@@ -230,7 +231,7 @@ function emitPerAttemptLatency() {
         latency,
         new stat.OutboundCallsPerAttemptLatencyTags(
             self.serviceName,
-            self.headers.cn,
+            self.callerName,
             self.endpoint,
             self.remoteAddr,
             self.retryCount
@@ -249,7 +250,7 @@ TChannelOutRequest.prototype.emitLatency = function emitLatency() {
         latency,
         new stat.OutboundCallsLatencyTags(
             self.serviceName,
-            self.headers.cn,
+            self.callerName,
             self.endpoint
         )
     ));
@@ -263,7 +264,7 @@ TChannelOutRequest.prototype.emitError = function emitError(err) {
             serviceName: self.serviceName,
             endpoint: self.endpoint,
             socketRemoteAddr: self.remoteAddr,
-            callerName: self.headers.cn,
+            callerName: self.callerName,
             oldError: self.err,
             oldResponse: !!self.res,
             error: err
@@ -310,7 +311,7 @@ TChannelOutRequest.prototype.emitResponse = function emitResponse(res) {
             serviceName: self.serviceName,
             endpoint: self.endpoint,
             socketRemoteAddr: self.remoteAddr,
-            callerName: self.headers.cn,
+            callerName: self.callerName,
             oldError: self.err,
             oldResponse: !!self.res
         });
@@ -442,7 +443,7 @@ TChannelOutRequest.prototype.send = function send(arg1, arg2, arg3, callback) {
 
     if (self.span) {
         self.span.annotateBinary('as', self.headers.as);
-        self.span.annotateBinary('cn', self.headers.cn);
+        self.span.annotateBinary('cn', self.callerName);
     }
 
     if (self.logical === false && self.retryCount === 0) {
@@ -467,7 +468,7 @@ function emitOutboundCallsSent() {
         1,
         new stat.OutboundCallsSentTags(
             self.serviceName,
-            self.headers.cn,
+            self.callerName,
             self.endpoint
         )
     ));
@@ -542,7 +543,7 @@ TChannelOutRequest.prototype.onTimeout = function onTimeout(now) {
             serviceName: self.serviceName,
             endpoint: self.endpoint,
             socketRemoteAddr: self.remoteAddr,
-            callerName: self.headers.cn,
+            callerName: self.callerName,
 
             oldError: self.err,
             oldResponse: !!self.res,
@@ -579,7 +580,7 @@ function emitOutboundCallsSuccess(request) {
         1,
         new stat.OutboundCallsSuccessTags(
             request.serviceName,
-            request.headers.cn,
+            request.callerName,
             request.endpoint
         )
     ));

--- a/out_response.js
+++ b/out_response.js
@@ -222,7 +222,7 @@ TChannelOutResponse.prototype.sendError = function sendError(codeString, message
         self.codeString = codeString;
         self.message = message;
         self.channel.inboundCallsSystemErrorsStat.increment(1, {
-            'calling-service': self.inreq.headers.cn,
+            'calling-service': self.inreq.callerName,
             'service': self.inreq.serviceName,
             'endpoint': String(self.inreq.arg1),
             'type': self.codeString
@@ -252,7 +252,7 @@ TChannelOutResponse.prototype.emitFinish = function emitFinish() {
         'timing',
         latency,
         new stat.InboundCallsLatencyTags(
-            self.inreq.headers.cn,
+            self.inreq.callerName,
             self.inreq.serviceName,
             self.inreq.endpoint
         )
@@ -327,7 +327,7 @@ TChannelOutResponse.prototype.send = function send(res1, res2) {
             'counter',
             1,
             new stat.InboundCallsSuccessTags(
-                self.inreq.headers.cn,
+                self.inreq.callerName,
                 self.inreq.serviceName,
                 self.inreq.endpoint
             )
@@ -339,7 +339,7 @@ TChannelOutResponse.prototype.send = function send(res1, res2) {
             'counter',
             1,
             new stat.InboundCallsAppErrorsTags(
-                self.inreq.headers.cn,
+                self.inreq.callerName,
                 self.inreq.serviceName,
                 self.inreq.endpoint,
                 'unknown'

--- a/request.js
+++ b/request.js
@@ -63,6 +63,7 @@ function TChannelRequest(options) {
     self.trackPending = self.options.trackPending || false;
 
     self.serviceName = options.serviceName || '';
+    self.callerName = options.headers && options.headers.cn || '';
     // so that as-foo can punch req.headers.X
     self.headers = self.options.headers;
 

--- a/request.js
+++ b/request.js
@@ -222,7 +222,7 @@ TChannelRequest.prototype.onIdentified = function onIdentified(peer) {
     if (self.outReqs.length !== 1) {
         self.channel.outboundCallsRetriesStat.increment(1, {
             'target-service': outReq.serviceName,
-            'service': outReq.headers.cn,
+            'service': outReq.callerName,
             // TODO should always be buffer
             'target-endpoint': String(self.arg1),
             'retry-count': self.outReqs.length - 1

--- a/test/request-with-statsd.js
+++ b/test/request-with-statsd.js
@@ -87,7 +87,7 @@ allocCluster.test('emits stats on call success', {
         client.flushStats();
 
         assert.ok(res.ok, 'res should be ok');
-        assert.deepEqual(statsd._buffer._elements, [{
+        [{
             type: 'c',
             name: 'tchannel.outbound.calls.sent.inPipe.reservoir.Reservoir--get',
             value: null,
@@ -141,7 +141,15 @@ allocCluster.test('emits stats on call success', {
             value: null,
             delta: null,
             time: 500
-        }], 'stats keys/values as expected');
+        }].forEach(function eachExpectedElement(elt, i, arr) {
+            if (i === 0) {
+                assert.equal(
+                    statsd._buffer._elements.length, arr.length,
+                    'expected number of stat elements');
+            }
+            assert.deepEqual(statsd._buffer._elements[i], elt,
+                             'stat[' + i + '] keys/values as expected');
+        });
 
         assert.end();
     }
@@ -213,7 +221,7 @@ allocCluster.test('emits stats on p2p call success', {
         client.flushStats();
 
         assert.ok(res.ok, 'res should be ok');
-        assert.deepEqual(statsd._buffer._elements, [{
+        [{
             type: 'c',
             name: 'tchannel.connections.initiated.' + serverHost,
             value: null,
@@ -261,7 +269,15 @@ allocCluster.test('emits stats on p2p call success', {
             value: null,
             delta: 1,
             time: null
-        }], 'stats keys/values as expected');
+        }].forEach(function eachExpectedElement(elt, i, arr) {
+            if (i === 0) {
+                assert.equal(
+                    statsd._buffer._elements.length, arr.length,
+                    'expected number of stat elements');
+            }
+            assert.deepEqual(statsd._buffer._elements[i], elt,
+                             'stat[' + i + '] keys/values as expected');
+        });
 
         assert.end();
     }
@@ -323,7 +339,7 @@ allocCluster.test('emits stats with no connection metrics', {
         client.flushStats();
 
         assert.ok(res.ok, 'res should be ok');
-        assert.deepEqual(statsd._buffer._elements, [{
+        [{
             type: 'c',
             name: 'tchannel.outbound.calls.sent.inPipe.reservoir.Reservoir--get',
             value: null,
@@ -359,7 +375,15 @@ allocCluster.test('emits stats with no connection metrics', {
             value: null,
             delta: null,
             time: 500
-        }], 'stats keys/values as expected');
+        }].forEach(function eachExpectedElement(elt, i, arr) {
+            if (i === 0) {
+                assert.equal(
+                    statsd._buffer._elements.length, arr.length,
+                    'expected number of stat elements');
+            }
+            assert.deepEqual(statsd._buffer._elements[i], elt,
+                             'stat[' + i + '] keys/values as expected');
+        });
 
         assert.end();
     }
@@ -424,7 +448,7 @@ allocCluster.test('emits stats on call failure', {
         client.flushStats();
 
         assert.ok(res.ok === false, 'res should be not ok');
-        assert.deepEqual(statsd._buffer._elements, [{
+        [{
             type: 'c',
             name: 'tchannel.outbound.calls.sent.inPipe.reservoir.Reservoir--get',
             value: null,
@@ -484,7 +508,15 @@ allocCluster.test('emits stats on call failure', {
             value: null,
             delta: null,
             time: 500
-        }], 'stats keys/values as expected');
+        }].forEach(function eachExpectedElement(elt, i, arr) {
+            if (i === 0) {
+                assert.equal(
+                    statsd._buffer._elements.length, arr.length,
+                    'expected number of stat elements');
+            }
+            assert.deepEqual(statsd._buffer._elements[i], elt,
+                             'stat[' + i + '] keys/values as expected');
+        });
 
         assert.end();
     }

--- a/test/request-with-statsd.js
+++ b/test/request-with-statsd.js
@@ -159,7 +159,7 @@ allocCluster.test('emits stats on p2p call success', {
     var serverHost = cluster.hosts[0]
         .split(':')[0]
         .replace(/\./g, '-');
-    var statsd = nullStatsd(9);
+    var statsd = nullStatsd(8);
 
     server.makeSubChannel({
         serviceName: 'reservoir'
@@ -276,7 +276,7 @@ allocCluster.test('emits stats with no connection metrics', {
 }, function t(cluster, assert) {
     var server = cluster.channels[0];
     var client = cluster.channels[1];
-    var statsd = nullStatsd(9);
+    var statsd = nullStatsd(6);
 
     server.makeSubChannel({
         serviceName: 'reservoir'

--- a/test/send.js
+++ b/test/send.js
@@ -529,7 +529,7 @@ allocCluster.test('send() with requestDefaults', 2, function t(cluster, assert) 
 
     subOne.handler.register('foo', function foo(req, res) {
         res.headers.as = 'raw';
-        res.sendOk('', req.headers.cn);
+        res.sendOk('', req.callerName);
     });
 
     subTwo.request({

--- a/v2/handler.js
+++ b/v2/handler.js
@@ -252,7 +252,7 @@ TChannelV2Handler.prototype.handleCallRequest = function handleCallRequest(reqFr
         'counter',
         reqFrame.size,
         new stat.InboundRequestSizeTags(
-            req.headers.cn,
+            req.callerName,
             req.serviceName,
             req.endpoint
         )
@@ -383,7 +383,7 @@ TChannelV2Handler.prototype.handleCallResponse = function handleCallResponse(res
         'counter',
         resFrame.size,
         new stat.InboundResponseSizeTags(
-            req ? req.headers.cn : '',
+            req ? req.callerName : '',
             req ? req.serviceName : '',
             req ? req.endpoint : ''
         )
@@ -431,7 +431,7 @@ TChannelV2Handler.prototype.handleCallRequestCont = function handleCallRequestCo
         'counter',
         reqFrame.size,
         new stat.InboundRequestSizeTags(
-            req.headers.cn,
+            req.callerName,
             req.serviceName,
             req.endpoint
         )
@@ -462,7 +462,7 @@ TChannelV2Handler.prototype.handleCallResponseCont = function handleCallResponse
         'counter',
         resFrame.size,
         new stat.InboundResponseSizeTags(
-            req ? req.headers.cn : '',
+            req ? req.callerName : '',
             req ? req.serviceName : '',
             req ? req.endpoint : ''
         )
@@ -619,7 +619,7 @@ function sendCallRequestFrame(req, flags, args) {
         req.id, reqBody, null,
         'tchannel.outbound.request.size', new stat.OutboundRequestSizeTags(
             req.serviceName,
-            req.headers.cn,
+            req.callerName,
             req.endpoint
         ));
 
@@ -654,7 +654,7 @@ function verifyCallRequestFrame(req, args) {
         } else {
             self.logger.error('Expected "as" header to be set for request', {
                 arg1: req.endpoint,
-                callerName: req.headers && req.headers.cn,
+                callerName: req.callerName,
                 remoteName: self.remoteName,
                 serviceName: req.serviceName,
                 socketRemoteAddr: self.connection.socketRemoteAddr
@@ -662,7 +662,7 @@ function verifyCallRequestFrame(req, args) {
         }
     }
 
-    if (!req.headers || !req.headers.cn) {
+    if (!req.callerName) {
         if (self.requireCn) {
             return errors.OutCnHeaderRequired();
         } else {
@@ -699,7 +699,7 @@ function sendCallResponseFrame(res, flags, args) {
         res.id, resBody, null,
         'tchannel.outbound.response.size', new stat.OutboundResponseSizeTags(
             req.serviceName,
-            req.headers.cn,
+            req.callerName,
             req.endpoint
         ));
 };
@@ -736,7 +736,7 @@ TChannelV2Handler.prototype.sendCallRequestContFrame = function sendCallRequestC
         req.id, reqBody, req.checksum,
         'tchannel.outbound.request.size', new stat.OutboundRequestSizeTags(
             req ? req.serviceName : '',
-            req ? req.headers.cn : '',
+            req ? req.callerName : '',
             req ? req.endpoint : ''
         ));
 };
@@ -754,7 +754,7 @@ TChannelV2Handler.prototype.sendCallResponseContFrame = function sendCallRespons
         res.id, resBody, res.checksum,
         'tchannel.outbound.response.size', new stat.OutboundResponseSizeTags(
             req.serviceName,
-            req.headers.cn,
+            req.callerName,
             req.endpoint
         ));
 };


### PR DESCRIPTION
To future proof against v3 and lazy reqs.

r @kriskowal @Raynos 