### PR TITLE
Unadvertise should drain before close

### DIFF
--- a/hyperbahn-client.js
+++ b/hyperbahn-client.js
@@ -380,8 +380,6 @@ function unadvertise(opts) {
     timers.clearTimeout(self._advertisementTimer);
     timers.clearTimeout(self.advertisementTimeoutTimer);
     self.latestAdvertisementResult = null;
-    self.state = States.UNADVERTISED;
-    self.emit('unadvertised');
     function unadvertiseInternalCb(error, result) {
         if (error) {
             self.logger.warn('HyperbahnClient: unadvertisement failure', {
@@ -391,6 +389,8 @@ function unadvertise(opts) {
             });
             return;
         }
+        self.state = States.UNADVERTISED;
+        self.emit('unadvertised');
     }
 };
 

--- a/hyperbahn-client.js
+++ b/hyperbahn-client.js
@@ -264,6 +264,7 @@ function sendRequest(opts, endpoint, cb) {
         timeout: (opts && opts.timeout) || self.defaultTimeout,
         hasNoParent: true,
         trace: false,
+        retryLimit: 1,
         headers: {
             cn: self.callerName
         }

--- a/hyperbahn-client.js
+++ b/hyperbahn-client.js
@@ -264,7 +264,6 @@ function sendRequest(opts, endpoint, cb) {
         timeout: (opts && opts.timeout) || self.defaultTimeout,
         hasNoParent: true,
         trace: false,
-        retryLimit: 1,
         headers: {
             cn: self.callerName
         }

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "tchannel",
   "description": "network multiplexing and framing protocol for RPC or parser drag racing",
   "author": "mranney@uber.com",
-  "version": "3.0.3",
+  "version": "3.0.4",
   "scripts": {
     "lint": "jshint .",
     "travis": "npm run test",

--- a/peer.js
+++ b/peer.js
@@ -472,12 +472,4 @@ TChannelPeer.prototype.getScore = function getScore() {
     return self.handler.getScore();
 };
 
-TChannelPeer.prototype.extendLogInfo = function extendLogInfo(info) {
-    var self = this;
-    self.channel.extendLogInfo(info);
-    info.hostPort = self.hostPort;
-    info.pendingIdentified = self.pendingIdentified;
-    return info;
-};
-
 module.exports = TChannelPeer;

--- a/peer.js
+++ b/peer.js
@@ -462,4 +462,12 @@ TChannelPeer.prototype.getScore = function getScore() {
     return self.handler.getScore();
 };
 
+TChannelPeer.prototype.extendLogInfo = function extendLogInfo(info) {
+    var self = this;
+    self.channel.extendLogInfo(info);
+    info.hostPort = self.hostPort;
+    info.pendingIdentified = self.pendingIdentified;
+    return info;
+};
+
 module.exports = TChannelPeer;


### PR DESCRIPTION
This is a follow-up for:
https://github.com/uber/hyperbahn/pull/3

Earlier the client changes the state to unadvertised once unadvertise call is made, without checking if the callback comes back successfully. This is because hyperbahn closes the peer and causes a connection reset error. That no longer happens because of graceful draining.

r: @Raynos @ShanniLi @jcorbin 

