### PR TITLE
Add a draining "signal" frame

### DIFF
--- a/connection.js
+++ b/connection.js
@@ -663,4 +663,24 @@ function sendLazyErrorFrame(reqFrame, codeString, message) {
         codeString, message);
 };
 
+TChannelConnection.prototype._drain =
+function _drain(reason, exempt) {
+    var self = this;
+
+    TChannelConnectionBase.prototype._drain.call(self, reason, exempt);
+
+    if (self.remoteName) {
+        sendDrainingFrame();
+    } else {
+        self.identifiedEvent.on(sendDrainingFrame);
+    }
+
+    function sendDrainingFrame() {
+        self.handler.sendErrorFrame(
+            v2.Frame.NullId, null,
+            'Declined',
+            'draining: ' + self.drainReason);
+    }
+};
+
 module.exports = TChannelConnection;

--- a/connection.js
+++ b/connection.js
@@ -280,10 +280,22 @@ TChannelConnection.prototype.onErrorFrame = function onErrorFrame(errFrame) {
         }));
         return;
 
+    case v2.ErrorResponse.Codes.Declined:
+        var match = /^draining:\s*(.+)$/.exec(errFrame.body.message);
+        if (match) {
+            self.draining = true;
+            self.drainReason = 'remote draining: ' + match[1];
+            // TODO:
+            // - info log?
+            // - invaliadet peer score?
+            return;
+        }
+        logUnhandled(v2.ErrorResponse.CodeNames[errFrame.body.code]);
+        break;
+
     case v2.ErrorResponse.Codes.BadRequest:
     case v2.ErrorResponse.Codes.Busy:
     case v2.ErrorResponse.Codes.Cancelled:
-    case v2.ErrorResponse.Codes.Declined:
     case v2.ErrorResponse.Codes.NetworkError:
     case v2.ErrorResponse.Codes.Timeout:
     case v2.ErrorResponse.Codes.UnexpectedError:

--- a/connection_base.js
+++ b/connection_base.js
@@ -93,9 +93,7 @@ TChannelConnectionBase.prototype.drain =
 function drain(reason, callback) {
     var self = this;
 
-    self.draining = true;
-    self.drainReason = reason;
-    self.ops.draining = true;
+    self._drain(reason);
 
     if (callback) {
         if (self.ops.hasDrained()) {
@@ -104,6 +102,15 @@ function drain(reason, callback) {
             self.ops.drainEvent.on(callback);
         }
     }
+};
+
+TChannelConnectionBase.prototype._drain =
+function _drain(reason) {
+    var self = this;
+
+    self.draining = true;
+    self.drainReason = reason;
+    self.ops.draining = true;
 };
 
 // create a request

--- a/test/chan_drain.js
+++ b/test/chan_drain.js
@@ -451,9 +451,10 @@ allocCluster.test('drain client with a few outgoing (with exempt service)', {
     var finishCount = 0;
     var reqN = 0;
     setupTestClients(cluster, ['a', 'b'], runTest);
+    drainClient.drainExempt = drainExemptB;
     setupServiceServer(server, 'a', 5);
     setupServiceServer(server, 'b', 5);
-    drainClient.drainExempt = drainExemptB;
+    server.drainExempt = drainExemptB;
 
     cluster.logger.whitelist('info', 'resetting connection');
     // cluster.logger.whitelist('info', 'ignoring outresponse.send on a closed connection');


### PR DESCRIPTION
When a connection starts draining, send a null-id'd declined error frame.

Note the message prefix is going to become a contract, since really this would be better off as a new frame type entirely; subsequent PR will branch essentially on "if the error has null id, and is declined, and the message starts with "draining:".

r @Raynos 
cc @blampe @prashantv @junchaowu 