### PR TITLE
Make drain exemption invariant per channel

### DIFF
--- a/channel.js
+++ b/channel.js
@@ -332,7 +332,7 @@ TChannel.prototype.setLazyHandling = function setLazyHandling(enabled) {
     }
 };
 
-TChannel.prototype.drain = function drain(reason, exempt, callback) {
+TChannel.prototype.drain = function drain(reason, callback) {
     var self = this;
 
     // TODO: we could do this by defaulting and/or forcing you into an
@@ -342,14 +342,8 @@ TChannel.prototype.drain = function drain(reason, exempt, callback) {
     assert(!self.topChannel, 'sub channel draining not supported');
     assert(!self.draining, 'channel already draining');
 
-    if (callback === undefined) {
-        callback = exempt;
-        exempt = null;
-    }
-
     self.draining = true;
     self.drainReason = reason;
-    self.drainExempt = exempt;
 
     var drained = CountedReadySignal(1);
     drained(callback);
@@ -362,7 +356,7 @@ TChannel.prototype.drain = function drain(reason, exempt, callback) {
 
     function drainEachConn(conn) {
         drained.counter++;
-        conn.drain(self.drainReason, self.drainExempt, drained.signal);
+        conn.drain(self.drainReason, drained.signal);
     }
 };
 
@@ -429,7 +423,7 @@ TChannel.prototype.onServerSocketConnection = function onServerSocketConnection(
     var conn = new TChannelConnection(chan, sock, 'in', socketRemoteAddr);
 
     if (self.draining) {
-        conn.drain(self.drainReason, self.drainExempt, null);
+        conn.drain(self.drainReason, null);
     }
 
     conn.errorEvent.on(onConnectionError);

--- a/operations.js
+++ b/operations.js
@@ -33,7 +33,6 @@ function Operations(opts) {
 
     EventEmitter.call(self);
     self.draining = false;
-    self.drainExempt = null;
     self.drainEvent = self.defineEvent('drain');
 
     self.timers = opts.timers;
@@ -263,8 +262,9 @@ Operations.prototype._isCollDrained = function _isCollDrained(coll) {
     for (var id in coll) {
         var op = coll[id];
         if (!(op instanceof OperationTombstone) &&
-            !op.drained &&
-            !(self.drainExempt && self.drainExempt(op))
+            !op.drained && !(
+                self.connection.channel.drainExempt &&
+                self.connection.channel.drainExempt(op))
         ) {
             return false;
         }

--- a/peer.js
+++ b/peer.js
@@ -404,7 +404,7 @@ TChannelPeer.prototype.makeOutConnection = function makeOutConnection(socket) {
     var conn = new TChannelConnection(chan, socket, 'out', self.hostPort);
 
     if (chan.draining) {
-        conn.drain(chan.drainReason, chan.drainExempt, null);
+        conn.drain(chan.drainReason, null);
     }
 
     self.allocConnectionEvent.emit(self, conn);

--- a/test/chan_drain.js
+++ b/test/chan_drain.js
@@ -169,6 +169,7 @@ allocCluster.test('drain server with a few incoming (with exempt service)', {
     setupTestClients(cluster, ['a', 'b'], runTest);
     setupServiceServer(server, 'a', 5);
     setupServiceServer(server, 'b', 5);
+    server.drainExempt = drainExemptB;
 
     function runTest(err, gotClients) {
         if (err) {
@@ -210,7 +211,7 @@ allocCluster.test('drain server with a few incoming (with exempt service)', {
         assert.equal(finishCount, 2, 'requests have not finished');
 
         finishCount++;
-        server.drain('testdown', drainExemptB, drained);
+        server.drain('testdown', drained);
 
         finishCount++;
         collectParallel(clients.a, sendOne, checkSendsDone('service:a', checkADecline, finish));
@@ -452,6 +453,7 @@ allocCluster.test('drain client with a few outgoing (with exempt service)', {
     setupTestClients(cluster, ['a', 'b'], runTest);
     setupServiceServer(server, 'a', 5);
     setupServiceServer(server, 'b', 5);
+    drainClient.drainExempt = drainExemptB;
 
     cluster.logger.whitelist('info', 'resetting connection');
     // cluster.logger.whitelist('info', 'ignoring outresponse.send on a closed connection');
@@ -496,7 +498,7 @@ allocCluster.test('drain client with a few outgoing (with exempt service)', {
         assert.equal(finishCount, 2, 'requests have not finished');
 
         finishCount++;
-        drainClient.drain('testdown', drainExemptB, drained);
+        drainClient.drain('testdown', drained);
 
         finishCount++;
         collectParallel(clients.a, sendOne, checkSendsDone('service:a', checkADecline, finish));


### PR DESCRIPTION
So that we can re-use the existing draining/drainReason touch points for remote-triggered draining (ala #9).

r @Raynos 