### PR TITLE
confuse TAP less

### DIFF
--- a/test/as-json.js
+++ b/test/as-json.js
@@ -100,7 +100,7 @@ allocCluster.test('sending using request()', {
     });
 });
 
-allocCluster.test('getting a not ok response', {
+allocCluster.test('getting a notOk response', {
     numPeers: 2
 }, function t(cluster, assert) {
     var tchannelJSON = makeTChannelJSONServer(cluster, {

--- a/test/as-thrift.js
+++ b/test/as-thrift.js
@@ -111,7 +111,7 @@ allocCluster.test('sending using request()', {
     });
 });
 
-allocCluster.test('send and receive a not ok', {
+allocCluster.test('send and receive a notOk', {
     numPeers: 2
 }, function t(cluster, assert) {
     var tchannelAsThrift = makeTChannelThriftServer(cluster, {
@@ -138,7 +138,7 @@ allocCluster.test('send and receive a not ok', {
     });
 });
 
-allocCluster.test('send and receive a typed not ok', {
+allocCluster.test('send and receive a typed notOk', {
     numPeers: 2
 }, function t(cluster, assert) {
     var tchannelAsThrift = makeTChannelThriftServer(cluster, {

--- a/test/request-with-statsd.js
+++ b/test/request-with-statsd.js
@@ -447,7 +447,7 @@ allocCluster.test('emits stats on call failure', {
 
         client.flushStats();
 
-        assert.ok(res.ok === false, 'res should be not ok');
+        assert.ok(res.ok === false, 'res should be notOk');
         [{
             type: 'c',
             name: 'tchannel.outbound.calls.sent.inPipe.reservoir.Reservoir--get',

--- a/test/response-stats.js
+++ b/test/response-stats.js
@@ -188,7 +188,7 @@ allocCluster.test('emits response stats with ok', {
     }
 });
 
-allocCluster.test('emits response stats with not ok', {
+allocCluster.test('emits response stats with notOk', {
     numPeers: 2,
     channelOptions: {
         statTags: {
@@ -243,7 +243,7 @@ allocCluster.test('emits response stats with not ok', {
 
         server.flushStats();
 
-        assert.equal(res.ok, false, 'res should be not ok');
+        assert.equal(res.ok, false, 'res should be notOk');
         assert.deepEqual(stats, [{
             name: 'tchannel.connections.accepted',
             type: 'counter',

--- a/test/response-with-statsd.js
+++ b/test/response-with-statsd.js
@@ -144,7 +144,7 @@ allocCluster.test('emits stats on response ok', {
     }
 });
 
-allocCluster.test('emits stats on response not ok', {
+allocCluster.test('emits stats on response notOk', {
     numPeers: 2,
     channelOptions: {
         timers: timers,
@@ -205,7 +205,7 @@ allocCluster.test('emits stats on response not ok', {
 
         server.flushStats();
 
-        assert.equal(res.ok, false, 'res should be not ok');
+        assert.equal(res.ok, false, 'res should be notOk');
         assert.deepEqual(statsd._buffer._elements, [{
             type: 'c',
             name: 'tchannel.connections.accepted.' + clientHost,

--- a/test/retry.js
+++ b/test/retry.js
@@ -182,7 +182,7 @@ allocCluster.test('request application retries', {
         assert.ok(
             req.outReqs[0].res &&
             !req.outReqs[0].res.ok,
-            'expected first res not ok');
+            'expected first res notOk');
         assert.equal(
             req.outReqs[0].res &&
             String(req.outReqs[0].res.arg3),
@@ -306,7 +306,7 @@ allocCluster.test('retryFlags work', {
                     'tchannel.timeout',
                     'expected first timeout error');
 
-                assert.ok(res.ok, 'expected to have not ok');
+                assert.ok(res.ok, 'expected to have notOk');
                 assert.ok(req.outReqs[1].res, 'expected to have 2nd response');
                 assert.equal(String(arg3), 'HI', 'got expected response');
 


### PR DESCRIPTION
I removed a bunch of `not ok` from the test blocks
and the asserts.

This makes ctrl+f "not ok" in travis 200% more effective

r: @jcorbin @kriskowal @shannili