### PR TITLE
Restore travis hyperbahn integration test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,4 +2,6 @@ language: node_js
 node_js:
   - "0.10"
 before_install: npm i npm@latest -g
-script: npm run travis
+script:
+- npm run travis
+- npm run hyperbahn-link-test

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "travis": "npm run test",
     "test": "npm run check-licence && npm run lint -s && npm run cover -s && npm run check-benchmark -s",
     "benchmark": "echo '!!! DEPRECATED: Better to just run `node benchmarks` directly' >&2; node benchmarks",
+    "hyperbahn-link-test": "npm link && cd $(mktemp -d) && git clone https://github.com/uber/hyperbahn . && npm install && npm link tchannel && npm run test-ci",
     "check-benchmark": "node benchmarks -- -r 10000 -p 10000",
     "take-benchmark": "make -C benchmarks take",
     "take-relay-benchmark": "make -C benchmarks take_relay",


### PR DESCRIPTION
Since 3.1.0 broke hyperbahn tests, and we didn't find out until too late.