### PR TITLE
Fix retryLimit off by one

### DIFF
--- a/request.js
+++ b/request.js
@@ -155,7 +155,7 @@ TChannelRequest.prototype.send = function send(arg1, arg2, arg3, callback) {
         self.hookupCallback(callback);
     }
     self.start = self.channel.timers.now();
-    self.resendSanity = self.limit + 1;
+    self.resendSanity = self.limit;
 
     TChannelOutRequest.prototype.emitOutboundCallsSent.call(self);
 
@@ -271,7 +271,7 @@ TChannelRequest.prototype.onSubreqResponse = function onSubreqResponse(res) {
 
 TChannelRequest.prototype.deferResend = function deferResend() {
     var self = this;
-    if (--self.resendSanity <= 0) {
+    if (--self.resendSanity < 0) {
         self.emitError(errors.RequestRetryLimitExceeded({
             limit: self.limit
         }));
@@ -320,7 +320,7 @@ TChannelRequest.prototype.checkTimeout = function checkTimeout(err, res) {
 TChannelRequest.prototype.shouldRetryError = function shouldRetryError(err) {
     var self = this;
 
-    if (self.outReqs.length >= self.limit) {
+    if (self.outReqs.length > self.limit) {
         return false;
     }
 

--- a/tcollector/reporter.js
+++ b/tcollector/reporter.js
@@ -147,7 +147,6 @@ function report(span, opts, callback) {
             shardKey: span.traceid.toString('base64')
         },
         serviceName: 'tcollector',
-        retryLimit: 1,
         retryFlags: {never: true}
     });
 

--- a/test/timeouts.js
+++ b/test/timeouts.js
@@ -154,8 +154,7 @@ allocCluster.test('requests will timeout per attempt', {
                     cn: 'wat'
                 },
                 timeout: 3000,
-                timeoutPerAttempt: 1000,
-                retryLimit: 1
+                timeoutPerAttempt: 1000
             })
             .send('/timeout', 'h', 'b', onTimeout);
 
@@ -250,7 +249,7 @@ allocCluster.test('requests can succeed after timeout per attempt', {
                 },
                 timeout: 3000,
                 timeoutPerAttempt: 1000,
-                retryLimit: 2
+                retryLimit: 1
             });
         req.send('/timeout', 'h', 'b', done);
     }


### PR DESCRIPTION
retryLimit, looking at the name, means max number of additional requests it should send. Current implementation takes initial request as first retry, and therefore is off by one.

After this fix, the behavior is:
0 no-retry (default)
1 retry once
2 retry twice
...

Fix hyperbahn as well:
https://github.com/uber/hyperbahn/pull/9

r: @Raynos @ShanniLi @jcorbin 