### PR TITLE
Pass error frames out of handler

### DIFF
--- a/connection.js
+++ b/connection.js
@@ -348,13 +348,14 @@ TChannelConnection.prototype.ping = function ping() {
 TChannelConnection.prototype.onCallError = function onCallError(err) {
     var self = this;
 
-    var req = self.ops.getOutReq(err.originalId);
+    var id = err.originalId;
+    var req = self.ops.getOutReq(id);
 
     if (req && req.res) {
         req.res.errorEvent.emit(req.res, err);
     } else {
         // Only popOutReq if there is no call response object yet
-        req = self.ops.popOutReq(err.originalId, err);
+        req = self.ops.popOutReq(id, err);
         if (!req) {
             return;
         }

--- a/connection.js
+++ b/connection.js
@@ -351,16 +351,14 @@ TChannelConnection.prototype.onCallError = function onCallError(err) {
     var id = err.originalId;
     var req = self.ops.getOutReq(id);
 
-    if (req && req.res) {
-        req.res.errorEvent.emit(req.res, err);
-    } else {
-        // Only popOutReq if there is no call response object yet
-        req = self.ops.popOutReq(id, err);
-        if (!req) {
-            return;
+    if (req) {
+        if (req.res) {
+            req.res.errorEvent.emit(req.res, err);
+        } else {
+            // Only popOutReq if there is no call response object yet
+            req = self.ops.popOutReq(id, err);
+            req.emitError(err);
         }
-
-        req.emitError(err);
     }
 };
 

--- a/connection.js
+++ b/connection.js
@@ -262,12 +262,6 @@ TChannelConnection.prototype.onWriteError = function onWriteError(err) {
 
 TChannelConnection.prototype.onHandlerError = function onHandlerError(err) {
     var self = this;
-
-    // TODO: why is err optional?
-    if (!err) {
-        return;
-    }
-
     self.resetAll(err);
 };
 

--- a/connection.js
+++ b/connection.js
@@ -216,8 +216,8 @@ TChannelConnection.prototype.setupHandler = function setupHandler() {
         self.handlePingResponse(res);
     }
 
-    function onCallError(err) {
-        self.onCallError(err);
+    function onCallError(errFrame) {
+        self.onCallError(errFrame);
     }
 };
 
@@ -345,11 +345,17 @@ TChannelConnection.prototype.ping = function ping() {
     return self.handler.sendPingRequest();
 };
 
-TChannelConnection.prototype.onCallError = function onCallError(err) {
+TChannelConnection.prototype.onCallError = function onCallError(errFrame) {
     var self = this;
 
-    var id = err.originalId;
+    var id = errFrame.id;
     var req = self.ops.getOutReq(id);
+
+    var codeErrorType = v2.ErrorResponse.CodeErrors[errFrame.body.code];
+    var err = codeErrorType({
+        originalId: id,
+        message: String(errFrame.body.message)
+    });
 
     if (req) {
         if (req.res) {

--- a/connection.js
+++ b/connection.js
@@ -166,7 +166,7 @@ TChannelConnection.prototype.setupHandler = function setupHandler() {
     self.handler.callIncomingRequestEvent.on(onCallRequest);
     self.handler.callIncomingResponseEvent.on(onCallResponse);
     self.handler.pingIncomingResponseEvent.on(onPingResponse);
-    self.handler.callIncomingErrorEvent.on(onCallError);
+    self.handler.callIncomingErrorFrameEvent.on(onCallErrorFrame);
 
     // TODO: restore dumping from old:
     // var stream = self.socket;
@@ -216,8 +216,8 @@ TChannelConnection.prototype.setupHandler = function setupHandler() {
         self.handlePingResponse(res);
     }
 
-    function onCallError(errFrame) {
-        self.onCallError(errFrame);
+    function onCallErrorFrame(errFrame) {
+        self.onCallErrorFrame(errFrame);
     }
 };
 
@@ -345,7 +345,8 @@ TChannelConnection.prototype.ping = function ping() {
     return self.handler.sendPingRequest();
 };
 
-TChannelConnection.prototype.onCallError = function onCallError(errFrame) {
+TChannelConnection.prototype.onCallErrorFrame =
+function onCallErrorFrame(errFrame) {
     var self = this;
 
     var id = errFrame.id;

--- a/connection.js
+++ b/connection.js
@@ -263,9 +263,12 @@ TChannelConnection.prototype.onWriteError = function onWriteError(err) {
 TChannelConnection.prototype.onHandlerError = function onHandlerError(err) {
     var self = this;
 
-    if (err) {
-        self.resetAll(err);
+    // TODO: why is err optional?
+    if (!err) {
+        return;
     }
+
+    self.resetAll(err);
 };
 
 TChannelConnection.prototype.handlePingResponse = function handlePingResponse(resFrame) {

--- a/connection.js
+++ b/connection.js
@@ -162,6 +162,7 @@ TChannelConnection.prototype.setupHandler = function setupHandler() {
 
     self.handler.writeErrorEvent.on(onWriteError);
     self.handler.errorEvent.on(onHandlerError);
+    self.handler.errorFrameEvent.on(onErrorFrame);
     self.handler.callIncomingRequestEvent.on(onCallRequest);
     self.handler.callIncomingResponseEvent.on(onCallResponse);
     self.handler.pingIncomingResponseEvent.on(onPingResponse);
@@ -193,6 +194,10 @@ TChannelConnection.prototype.setupHandler = function setupHandler() {
 
     function onHandlerError(err) {
         self.onHandlerError(err);
+    }
+
+    function onErrorFrame(errFrame) {
+        self.onErrorFrame(errFrame);
     }
 
     function handleReadFrame(frame) {
@@ -258,6 +263,18 @@ TChannelConnection.prototype.onWriteError = function onWriteError(err) {
     var self = this;
 
     self.sendProtocolError('write', err);
+};
+
+TChannelConnection.prototype.onErrorFrame = function onErrorFrame(errFrame) {
+    var self = this;
+
+    // TODO: too coupled to v2
+
+    var codeErrorType = v2.ErrorResponse.CodeErrors[errFrame.body.code];
+    self.resetAll(codeErrorType({
+        originalId: errFrame.id,
+        message: String(errFrame.body.message)
+    }));
 };
 
 TChannelConnection.prototype.onHandlerError = function onHandlerError(err) {

--- a/v2/handler.js
+++ b/v2/handler.js
@@ -498,15 +498,14 @@ TChannelV2Handler.prototype.handleError = function handleError(errFrame, callbac
         message: String(errFrame.body.message)
     });
 
-    delete self.streamingReq[errFrame.id];
-    delete self.streamingRes[errFrame.id];
-
     if (errFrame.id === v2.Frame.NullId) {
         // fatal error not associated with a prior frame
         self.errorEvent.emit(self, err);
         return;
     }
 
+    delete self.streamingReq[errFrame.id];
+    delete self.streamingRes[errFrame.id];
     self.callIncomingErrorEvent.emit(self, err);
 };
 

--- a/v2/handler.js
+++ b/v2/handler.js
@@ -501,11 +501,7 @@ TChannelV2Handler.prototype.handleError = function handleError(errFrame, callbac
 
     delete self.streamingReq[errFrame.id];
     delete self.streamingRes[errFrame.id];
-    var codeErrType = v2.ErrorResponse.CodeErrors[errFrame.body.code];
-    self.callIncomingErrorEvent.emit(self, codeErrType({
-        originalId: errFrame.id,
-        message: String(errFrame.body.message)
-    }));
+    self.callIncomingErrorEvent.emit(self, errFrame);
 };
 
 TChannelV2Handler.prototype._checkCallFrame = function _checkCallFrame(r, frame) {

--- a/v2/handler.js
+++ b/v2/handler.js
@@ -52,7 +52,7 @@ function TChannelV2Handler(options) {
     EventEmitter.call(self);
     self.errorEvent = self.defineEvent('error');
     self.errorFrameEvent = self.defineEvent('errorFrame');
-    self.callIncomingErrorEvent = self.defineEvent('callIncomingError');
+    self.callIncomingErrorFrameEvent = self.defineEvent('callIncomingErrorFrame');
     self.callIncomingRequestEvent = self.defineEvent('callIncomingRequest');
     self.callIncomingResponseEvent = self.defineEvent('callIncomingResponse');
     self.cancelEvent = self.defineEvent('cancel');
@@ -501,7 +501,7 @@ TChannelV2Handler.prototype.handleError = function handleError(errFrame, callbac
 
     delete self.streamingReq[errFrame.id];
     delete self.streamingRes[errFrame.id];
-    self.callIncomingErrorEvent.emit(self, errFrame);
+    self.callIncomingErrorFrameEvent.emit(self, errFrame);
 };
 
 TChannelV2Handler.prototype._checkCallFrame = function _checkCallFrame(r, frame) {

--- a/v2/handler.js
+++ b/v2/handler.js
@@ -492,18 +492,16 @@ TChannelV2Handler.prototype.handlePingResponse = function handlePingResponse(pin
 TChannelV2Handler.prototype.handleError = function handleError(errFrame, callback) {
     var self = this;
 
-    var id = errFrame.id;
-    var code = errFrame.body.code;
-    var message = String(errFrame.body.message);
-    var err = v2.ErrorResponse.CodeErrors[code]({
-        originalId: id,
-        message: message
+    var codeErrType = v2.ErrorResponse.CodeErrors[errFrame.body.code];
+    var err = codeErrType({
+        originalId: errFrame.id,
+        message: String(errFrame.body.message)
     });
 
-    delete self.streamingReq[id];
-    delete self.streamingRes[id];
+    delete self.streamingReq[errFrame.id];
+    delete self.streamingRes[errFrame.id];
 
-    if (id === v2.Frame.NullId) {
+    if (errFrame.id === v2.Frame.NullId) {
         // fatal error not associated with a prior frame
         self.errorEvent.emit(self, err);
     } else {

--- a/v2/handler.js
+++ b/v2/handler.js
@@ -504,9 +504,10 @@ TChannelV2Handler.prototype.handleError = function handleError(errFrame, callbac
     if (errFrame.id === v2.Frame.NullId) {
         // fatal error not associated with a prior frame
         self.errorEvent.emit(self, err);
-    } else {
-        self.callIncomingErrorEvent.emit(self, err);
+        return;
     }
+
+    self.callIncomingErrorEvent.emit(self, err);
 };
 
 TChannelV2Handler.prototype._checkCallFrame = function _checkCallFrame(r, frame) {


### PR DESCRIPTION
Prep before #15, which will continue work in `TChannelConnection#onErrorFrame`, and not always construct an error object. 

r @Raynos @rf 