### PR TITLE
WIP: add TChannelHTTP#runHTTPHandler

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "sse4_crc32": "3.2.0",
     "tape-cluster": "2.1.0",
     "thriftrw": "2.2.4",
+    "uber-hammock": "^1.0.0",
     "uber-statsd-client": "1.3.2",
     "xtend": "^4.0.0"
   },


### PR DESCRIPTION
TODO:
- [ ] probably don't use (uber-)hammock, just inline mock http req/res classes
- [ ] tests
- [ ] examples

To address @MadanThangavelu's current needs in an internal service, and based on the request proxy pattern already present in ringpop ala.

r @Raynos 
cc @MadanThangavelu @Matt-Esch @jwolski 
