### PR TITLE
move hyperbahn-client tests back into tchannel-node

### DIFF
--- a/test/hyperbahn-client/constructor.js
+++ b/test/hyperbahn-client/constructor.js
@@ -1,0 +1,115 @@
+// Copyright (c) 2015 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+'use strict';
+
+var test = require('tape');
+var DebugLogtron = require('debug-logtron');
+
+var TChannel = require('../../');
+var HyperbahnClient = require('../../hyperbahn/index.js');
+
+test('creating HyperbahnClient with new', function t(assert) {
+    var logger = DebugLogtron('hyperbahnclient');
+
+    var c = new HyperbahnClient({
+        tchannel: TChannel({
+            logger: logger
+        }),
+        serviceName: 'foo',
+        callerName: 'foo-test',
+        hostPortList: [],
+        logger: logger
+    });
+
+    assert.ok(c, 'can create a client');
+
+    c.tchannel.close();
+    assert.end();
+});
+
+test('create HyperbahnClient without options', function t(assert) {
+    assert.throws(function throwIt() {
+        HyperbahnClient();
+    }, /Must pass in top level tchannel/);
+
+    assert.end();
+});
+
+test('create HyperbahnClient without options.tchannel', function t(assert) {
+    assert.throws(function throwIt() {
+        HyperbahnClient({});
+    }, /Must pass in top level tchannel/);
+
+    assert.end();
+});
+
+test('create HyperbahnClient with a subchannel', function t(assert) {
+    var tchannel = TChannel();
+    assert.throws(function throwIt() {
+        HyperbahnClient({
+            tchannel: tchannel.makeSubChannel({
+                serviceName: 'foo'
+            })
+        });
+    }, /Must pass in top level tchannel/);
+
+    tchannel.close();
+    assert.end();
+});
+
+test('create HyperbahnClient without serviceName', function t(assert) {
+    var tchannel = TChannel();
+    assert.throws(function throwIt() {
+        HyperbahnClient({
+            tchannel: tchannel
+        });
+    }, /must pass in serviceName/);
+
+    tchannel.close();
+    assert.end();
+});
+
+test('create HyperbahnClient without hostPortList', function t(assert) {
+    var tchannel = TChannel();
+    assert.throws(function throwIt() {
+        HyperbahnClient({
+            tchannel: tchannel,
+            serviceName: 'foo'
+        });
+    }, /Must pass in hostPortList as array or hostPortFile as string/);
+
+    tchannel.close();
+    assert.end();
+});
+
+test('create HyperbahnClient with bad hostPortFile', function t(assert) {
+    var tchannel = TChannel();
+    assert.throws(function throwIt() {
+        HyperbahnClient({
+            tchannel: tchannel,
+            serviceName: 'foo',
+            hostPortFile: '~~~~~'
+        });
+    }, /Read host port list failed with Error: ENOENT, no such file or directory \'~~~~~\'/);
+
+    tchannel.close();
+    assert.end();
+});

--- a/test/hyperbahn-client/sub-channel.js
+++ b/test/hyperbahn-client/sub-channel.js
@@ -1,0 +1,85 @@
+// Copyright (c) 2015 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+'use strict';
+
+var test = require('tape');
+
+var TChannel = require('../../');
+var HyperbahnClient = require('../../hyperbahn/index.js');
+
+test('getting client subChannel without serviceName', function t(assert) {
+    var client = HyperbahnClient({
+        tchannel: TChannel(),
+        serviceName: 'foo',
+        callerName: 'foo-test',
+        hostPortList: []
+    });
+
+    assert.throws(function throwIt() {
+        client.getClientChannel();
+    }, /must pass serviceName/);
+
+    assert.throws(function throwIt() {
+        client.getClientChannel({});
+    }, /must pass serviceName/);
+
+    client.tchannel.close();
+    assert.end();
+});
+
+test('getting a client subChannel', function t(assert) {
+    var client = HyperbahnClient({
+        tchannel: TChannel(),
+        serviceName: 'foo',
+        callerName: 'foo-test',
+        hostPortList: []
+    });
+
+    var subChannel = client.getClientChannel({
+        serviceName: 'bar'
+    });
+
+    assert.equal(subChannel.topChannel, client.tchannel);
+
+    client.tchannel.close();
+    assert.end();
+});
+
+test('double getting a client subChannel', function t(assert) {
+    var client = HyperbahnClient({
+        tchannel: TChannel(),
+        serviceName: 'foo',
+        callerName: 'foo-test',
+        hostPortList: []
+    });
+
+    var subChannel1 = client.getClientChannel({
+        serviceName: 'bar'
+    });
+    var subChannel2 = client.getClientChannel({
+        serviceName: 'bar'
+    });
+
+    assert.equal(subChannel1, subChannel2);
+
+    client.tchannel.close();
+    assert.end();
+});

--- a/test/index.js
+++ b/test/index.js
@@ -88,3 +88,6 @@ require('./v2/ping.js');
 require('./v2/error_response.js');
 require('./v2/args.js');
 require('./v2/lazy_frame.js');
+
+require('./hyperbahn-client/constructor.js');
+require('./hyperbahn-client/sub-channel.js');


### PR DESCRIPTION
I accidentaly too #fierce the tests into hyperbahn repository.

This moves some of the tests back.

r: @jcorbin @kriskowal