### PR TITLE
Fix connection leak during peer close

### DIFF
--- a/peer.js
+++ b/peer.js
@@ -164,9 +164,9 @@ TChannelPeer.prototype.close = function close(callback) {
 
     var counter = self.connections.length;
     if (counter) {
-        self.connections.forEach(function eachConn(conn) {
-            conn.close(onClose);
-        });
+        for (var i = counter - 1; i >= 0; i--) {
+            self.connections[i].close(onClose);
+        }
     } else {
         callback(null);
     }

--- a/test/peer.js
+++ b/test/peer.js
@@ -21,6 +21,8 @@
 'use strict';
 
 var allocCluster = require('./lib/alloc-cluster.js');
+var TChannelConnection = require('../connection.js');
+var net = require('net');
 
 allocCluster.test('peer should use the identified connection', {
     numPeers: 2
@@ -104,4 +106,42 @@ allocCluster.test('peer should return the latest connection when none is identif
     client.close();
     server.close();
     assert.end();
+});
+
+allocCluster.test('peer close should not leak connections', {
+    numPeers: 2
+}, function t(cluster, assert) {
+    var server = cluster.channels[0];
+    var client = cluster.channels[1];
+    var serverHost = cluster.hosts[0];
+
+    server.makeSubChannel({
+        serviceName: 'server'
+    });
+
+    var subClient = client.makeSubChannel({
+        serviceName: 'server',
+        peers: [server.hostPort]
+    });
+
+    var peer = subClient.peers.get(serverHost);
+    var connection = peer.connect();
+    connection.identifiedEvent.on(onIdentified);
+    function onIdentified() {
+        peer = server.peers.values()[0];
+        var socket = peer.makeOutSocket();
+        var conn = peer.makeOutConnection(socket);
+        peer.addConnection(conn);
+        var count = 2;
+        peer.removeConnectionEvent.on(function onClose() {
+            count--;
+        });
+
+        peer.close(function onClose() {
+            assert.equals(0, count, 'both connections should be closed');
+            client.close();
+            server.close();
+            assert.end();
+        });
+    }
 });

--- a/test/peer.js
+++ b/test/peer.js
@@ -21,8 +21,6 @@
 'use strict';
 
 var allocCluster = require('./lib/alloc-cluster.js');
-var TChannelConnection = require('../connection.js');
-var net = require('net');
 
 allocCluster.test('peer should use the identified connection', {
     numPeers: 2


### PR DESCRIPTION
When a peer has more than one connections, peer close always leaks one.

r: @Raynos @jcorbin @ShanniLi 