### PR TITLE
Assert against chan.listen() on sub-channels

### DIFF
--- a/channel.js
+++ b/channel.js
@@ -561,6 +561,7 @@ TChannel.prototype.listen = function listen(port, host, callback) {
     //   available ephemeral port
     // - 127.0.0.1 is a valid host, primarily for testing
     var self = this;
+    assert(!self.topChannel, 'TChannel must listen on top channel');
     assert(!self.listened, 'TChannel can only listen once');
     assert(typeof host === 'string', 'TChannel requires host argument');
     assert(typeof port === 'number', 'TChannel must listen with numeric port');


### PR DESCRIPTION
causes unexpected test failure, needs tweaks.

test failure here:

  https://github.com/uber/tchannel-node/issues/30#issuecomment-144597268