### PR TITLE
Stabilize unadvertise test part one

### DIFF
--- a/hyperbahn-client.js
+++ b/hyperbahn-client.js
@@ -380,8 +380,6 @@ function unadvertise(opts) {
     timers.clearTimeout(self._advertisementTimer);
     timers.clearTimeout(self.advertisementTimeoutTimer);
     self.latestAdvertisementResult = null;
-    self.state = States.UNADVERTISED;
-    self.emit('unadvertised');
     function unadvertiseInternalCb(error, result) {
         if (error) {
             self.logger.warn('HyperbahnClient: unadvertisement failure', {
@@ -391,6 +389,8 @@ function unadvertise(opts) {
             });
             return;
         }
+        self.state = States.UNADVERTISED;
+        self.emit('unadvertised');
     }
 };
 

--- a/peer.js
+++ b/peer.js
@@ -382,7 +382,7 @@ TChannelPeer.prototype.removeConnection = function removeConnection(conn) {
 
     self._maybeInvalidateScore();
 
-    self.removeConnectionEvent.emit(self);
+    self.removeConnectionEvent.emit(self, conn);
     return ret;
 };
 


### PR DESCRIPTION
This is tchannel part of change to stabilize unadvertise test.
1. unadvertise state change and event emit should wait for callback to succeed
2. removeConnectionEvent should emit along with conn, so the event listener can do sth

This change need be in before hyperbahn change:
https://github.com/uber/hyperbahn/pull/23

Multiple test runs passed
```bash
for i in {1..50}; do node unadvertise.js; done
```

r: @Raynos @ShanniLi