### PR TITLE
Add errors.isFatal

### DIFF
--- a/errors.js
+++ b/errors.js
@@ -826,6 +826,29 @@ module.exports.toHTTPCode = function toHTTPCode(codeName) {
     }
 };
 
+module.exports.isFatal = function isFatal(err, codeName) {
+    if (!codeName) {
+        codeName = module.exports.classify(err);
+    }
+    switch (codeName) {
+        case 'Busy':
+        case 'Cancelled':
+        case 'Declined':
+        case 'NetworkError':
+        case 'Timeout':
+        case 'Unhealthy':
+            return false;
+
+        case 'BadRequest':
+        case 'ProtocolError':
+        case 'UnexpectedError':
+            return true;
+
+        default:
+            return true;
+    }
+};
+
 module.exports.logLevel = function errorLogLevel(err, codeName) {
     switch (codeName) {
         case 'ProtocolError':


### PR DESCRIPTION
The idea for this started with hyperbahn relay ad.  The intention is that this function can be used by an application to say "is this error exceptional?" to guide such things as error logging (vs downgrading to a warn, info, or just silencing).

r @kriskowal @Raynos 