### PR TITLE
Add a method to AsThrift to load Meta thrift synchronously

### DIFF
--- a/as/thrift.js
+++ b/as/thrift.js
@@ -66,17 +66,13 @@ function TChannelAsThrift(opts) {
         'channel must be provided with isHealthy');
 
     if (self.isHealthy) {
-        fs.readFile(path.join(__dirname, 'meta.thrift'), 'utf8', registerHealthCheck);
+        var thriftSource = fs.readFileSync(
+            path.join(__dirname, 'meta.thrift'), 'utf8'
+        );
+        registerHealthCheck(thriftSource);
     }
 
-    function registerHealthCheck(err, source) {
-        if (err) {
-            self.channel.logger.error('failed to read meta.thrift file', {
-                error: err
-            });
-            return;
-        }
-
+    function registerHealthCheck(source) {
         self.thriftSource = opts.source;
         var metaSpec = new thriftrw.Thrift({
             source: source

--- a/as/thrift.js
+++ b/as/thrift.js
@@ -82,28 +82,6 @@ function TChannelAsThrift(opts) {
     }
 }
 
-function health(self, req, head, body, callback) {
-    var status = self.isHealthy();
-    assert(status && typeof status.ok === 'boolean', 'status must have ok field');
-    assert(status && (status.ok || typeof status.message === 'string'),
-        'status.message must be provided when status.ok === false');
-
-    return callback(null, {
-        ok: true,
-        body: {
-            ok: status.ok,
-            message: status.message
-        }
-    });
-}
-
-function thriftIDL(self, req, head, body, callback) {
-    return callback(null, {
-        ok: true,
-        body: self.thriftSource
-    });
-}
-
 TChannelAsThrift.prototype.request = function request(reqOptions) {
     var self = this;
 
@@ -431,6 +409,28 @@ function send(endpoint, head, body, callback) {
     var outreq = self.channel.request(self.reqOptions);
     self.tchannelThrift.send(outreq, endpoint, head, body, callback);
 };
+
+function health(self, req, head, body, callback) {
+    var status = self.isHealthy();
+    assert(status && typeof status.ok === 'boolean', 'status must have ok field');
+    assert(status && (status.ok || typeof status.message === 'string'),
+        'status.message must be provided when status.ok === false');
+
+    return callback(null, {
+        ok: true,
+        body: {
+            ok: status.ok,
+            message: status.message
+        }
+    });
+}
+
+function thriftIDL(self, req, head, body, callback) {
+    return callback(null, {
+        ok: true,
+        body: self.thriftSource
+    });
+}
 
 // TODO proper Thriftify result union that reifies as the selected field.
 function onlyKey(object) {

--- a/as/thrift.js
+++ b/as/thrift.js
@@ -82,14 +82,6 @@ function TChannelAsThrift(opts) {
     }
 }
 
-function TChannelThriftRequest(options) {
-    var self = this;
-
-    self.channel = options.channel;
-    self.reqOptions = options.reqOptions;
-    self.tchannelThrift = options.tchannelThrift;
-}
-
 function health(self, req, head, body, callback) {
     var status = self.isHealthy();
     assert(status && typeof status.ok === 'boolean', 'status must have ok field');
@@ -111,14 +103,6 @@ function thriftIDL(self, req, head, body, callback) {
         body: self.thriftSource
     });
 }
-
-TChannelThriftRequest.prototype.send =
-function send(endpoint, head, body, callback) {
-    var self = this;
-
-    var outreq = self.channel.request(self.reqOptions);
-    self.tchannelThrift.send(outreq, endpoint, head, body, callback);
-};
 
 TChannelAsThrift.prototype.request = function request(reqOptions) {
     var self = this;
@@ -281,17 +265,6 @@ function send(request, endpoint, outHead, outBody, callback) {
     }
 };
 
-function TChannelThriftResponse(response, parseResult) {
-    var self = this;
-
-    self.ok = response.ok;
-    self.head = parseResult.head;
-    self.body = null;
-    self.headers = response.headers;
-    self.body = parseResult.body;
-    self.typeName = parseResult.typeName;
-}
-
 TChannelAsThrift.prototype._parse = function parse(opts) {
     var self = this;
     var spec = opts.spec || self.spec;
@@ -430,6 +403,33 @@ TChannelAsThrift.prototype._stringify = function stringify(opts) {
         head: headRes.value,
         body: bodyRes.value
     });
+};
+
+function TChannelThriftResponse(response, parseResult) {
+    var self = this;
+
+    self.ok = response.ok;
+    self.head = parseResult.head;
+    self.body = null;
+    self.headers = response.headers;
+    self.body = parseResult.body;
+    self.typeName = parseResult.typeName;
+}
+
+function TChannelThriftRequest(options) {
+    var self = this;
+
+    self.channel = options.channel;
+    self.reqOptions = options.reqOptions;
+    self.tchannelThrift = options.tchannelThrift;
+}
+
+TChannelThriftRequest.prototype.send =
+function send(endpoint, head, body, callback) {
+    var self = this;
+
+    var outreq = self.channel.request(self.reqOptions);
+    self.tchannelThrift.send(outreq, endpoint, head, body, callback);
 };
 
 // TODO proper Thriftify result union that reifies as the selected field.

--- a/test/health.js
+++ b/test/health.js
@@ -185,8 +185,10 @@ function makeTChannelThriftServer(cluster, opts) {
         source: thriftSource,
         logParseFailures: false,
         channel: cluster.channels[0].subChannels.server,
-        isHealthy: health
+        isHealthy: health,
+        loadMetaAsync: false
     });
+    tchannelAsThrift.registerHealthSync();
     tchannelAsThrift.register(server, 'Chamber::echo', options, okHandler);
 
     return tchannelAsThrift;


### PR DESCRIPTION
This refactors a bunch of code in AsThrift and adds a sync
helper that will deterministically load your meta thrift
file synchronously rather then asynchronously.

This fixes flappy BadRequests in the tests because of 
file IO & TCP IO race conditions.

r: @jcorbin @kriskowal