### PR TITLE
[SEMVER-MAJOR]: hyperbahn-client: ban the ability to create a client channel for yourself

### DIFF
--- a/hyperbahn-client.js
+++ b/hyperbahn-client.js
@@ -189,13 +189,16 @@ function getClientChannel(options) {
         return null;
     }
 
-    if (self.tchannel.subChannels[options.serviceName]) {
-        return self.tchannel.subChannels[options.serviceName];
+    var channelName = options.channelName || options.serviceName;
+
+    if (self.tchannel.subChannels[channelName]) {
+        assert(false, 'HyperbahnClient cannot get client channel. ' +
+            'channel already exists: ' + channelName);
     }
 
     var channelOptions = {
         peers: self.hostPortList,
-        serviceName: options.serviceName,
+        serviceName: channelName,
         preferConnectionDirection: 'in',
         requestDefaults: {
             serviceName: options.serviceName,

--- a/test/hyperbahn-client/sub-channel.js
+++ b/test/hyperbahn-client/sub-channel.js
@@ -64,22 +64,114 @@ test('getting a client subChannel', function t(assert) {
 });
 
 test('double getting a client subChannel', function t(assert) {
+    var channel = TChannel();
     var client = HyperbahnClient({
-        tchannel: TChannel(),
+        tchannel: channel,
         serviceName: 'foo',
         callerName: 'foo-test',
         hostPortList: []
     });
 
-    var subChannel1 = client.getClientChannel({
-        serviceName: 'bar'
-    });
-    var subChannel2 = client.getClientChannel({
+    client.getClientChannel({
         serviceName: 'bar'
     });
 
-    assert.equal(subChannel1, subChannel2);
+    assert.throws(function throwIt() {
+        client.getClientChannel({
+            serviceName: 'bar'
+        });
+    });
 
-    client.tchannel.close();
+    channel.makeSubChannel({
+        serviceName: 'lul'
+    });
+
+    assert.throws(function throwIt() {
+        client.getClientChannel({
+            serviceName: 'lul'
+        });
+    });
+
+    channel.close();
     assert.end();
+});
+
+test('calling self with two sub channels', function t(assert) {
+    function ChannelApp() {
+        if (!(this instanceof ChannelApp)) {
+            return new ChannelApp();
+        }
+
+        var self = this;
+
+        self.channel = TChannel();
+        self.serverChan = self.channel.makeSubChannel({
+            serviceName: 'my-app'
+        });
+        self.hyperbahn = HyperbahnClient({
+            tchannel: self.channel,
+            serviceName: 'my-app',
+            callerName: 'my-app',
+            hostPortList: []
+        });
+
+        self.clientChan = self.hyperbahn.getClientChannel({
+            serviceName: 'my-app',
+            channelName: 'my-app-client'
+        });
+    }
+
+    ChannelApp.prototype.start = function start(onListen) {
+        var self = this;
+
+        self.channel.listen(0, '127.0.0.1', onListen);
+    };
+
+    ChannelApp.prototype.close = function close() {
+        var self = this;
+
+        self.channel.close();
+    };
+
+    var a = ChannelApp();
+    var b = ChannelApp();
+    var count = 2;
+
+    a.start(onStarted);
+    b.start(onStarted);
+
+    function onStarted() {
+        if (--count === 0) {
+            runRequests();
+        }
+    }
+
+    function runRequests() {
+        a.serverChan.register('echo', function echo(req, res, arg2, arg3) {
+            res.headers.as = 'raw';
+            res.sendOk(arg2, arg3);
+        });
+
+        b.clientChan.peers.add(a.channel.hostPort);
+
+        b.clientChan.request({
+            hasNoParent: true,
+            headers: {
+                as: 'raw'
+            }
+        }).send('echo', 'a', 'b', onResponse);
+
+        function onResponse(err, resp, arg2, arg3) {
+            assert.ifError(err);
+
+            assert.ok(resp.ok);
+            assert.equal(arg2.toString(), 'a');
+            assert.equal(arg3.toString(), 'b');
+
+            a.close();
+            b.close();
+
+            assert.end();
+        }
+    }
 });


### PR DESCRIPTION
This change cleans up an edge case that was previously confusing.

Now when you try and create a duplicate sub channel it simply tells you
to go away.

This reduces confusion around whether requestDefaults and the like
are set properly.
