### PR TITLE
only emit relay.latency after writing bytes to socket

### DIFF
--- a/relay_handler.js
+++ b/relay_handler.js
@@ -562,18 +562,18 @@ RelayRequest.prototype.onIdentified = function onIdentified() {
     self.outreq.responseEvent.on(onResponse);
     self.outreq.errorEvent.on(self.boundOnError);
 
+    if (self.outreq.streamed) {
+        self.outreq.sendStreams(self.inreq.arg1, self.inreq.arg2, self.inreq.arg3);
+    } else {
+        self.outreq.send(self.inreq.arg1, self.inreq.arg2, self.inreq.arg3);
+    }
+
     self.channel.emitFastStat(self.channel.buildStat(
         'tchannel.relay.latency',
         'timing',
         elapsed,
         {}
     ));
-
-    if (self.outreq.streamed) {
-        self.outreq.sendStreams(self.inreq.arg1, self.inreq.arg2, self.inreq.arg3);
-    } else {
-        self.outreq.send(self.inreq.arg1, self.inreq.arg2, self.inreq.arg3);
-    }
 
     function onResponse(res) {
         self.onResponse(res);

--- a/test/relay-stats.js
+++ b/test/relay-stats.js
@@ -69,17 +69,6 @@ var fixture = [
         }
     },
     {
-        "name": "tchannel.relay.latency",
-        "type": "timing",
-        "value": isNumber,
-        "tags": {
-            "app": "",
-            "host": "",
-            "cluster": "",
-            "version": ""
-        }
-    },
-    {
         "name": "tchannel.outbound.calls.sent",
         "type": "counter",
         "value": isNumber,
@@ -105,6 +94,17 @@ var fixture = [
             "targetService": "two",
             "service": "wat",
             "targetEndpoint": "echo"
+        }
+    },
+    {
+        "name": "tchannel.relay.latency",
+        "type": "timing",
+        "value": isNumber,
+        "tags": {
+            "app": "",
+            "host": "",
+            "cluster": "",
+            "version": ""
         }
     },
     {


### PR DESCRIPTION
We spend non-trivial CPU in the entire bufrw and net.Socket
layer converting call response into bytes.

We need to capture that in this stat

r: @rf @jcorbin @kriskowal