### PR TITLE
[as-http] Remove request body size limit

### DIFF
--- a/as/http.js
+++ b/as/http.js
@@ -185,7 +185,8 @@ TChannelHTTP.prototype.sendRequest = function send(treq, hreq, options, callback
         return treq.sendStreams(arg1, arg2, hreq, onStreamResponse);
     }
     getRawBody(hreq, {
-        length: hreq.headers['content-length']
+        length: hreq.headers['content-length'],
+        limit: '20mb'
     }, onRawBody);
 
     function onRawBody(err, body) {

--- a/as/http.js
+++ b/as/http.js
@@ -185,8 +185,7 @@ TChannelHTTP.prototype.sendRequest = function send(treq, hreq, options, callback
         return treq.sendStreams(arg1, arg2, hreq, onStreamResponse);
     }
     getRawBody(hreq, {
-        length: hreq.headers['content-length'],
-        limit: '1mb'
+        length: hreq.headers['content-length']
     }, onRawBody);
 
     function onRawBody(err, body) {


### PR DESCRIPTION
It turns out that request body can be larger than 1 mb, so remove the limit to avoid getting 413 error code

@vipulaneja  @jcorbin @ShanniLi