### PR TITLE
Add lazy v2 call header reading

### DIFF
--- a/test/v2/lazy_frame.js
+++ b/test/v2/lazy_frame.js
@@ -262,6 +262,28 @@ test('CallResponse.RW.lazy', function t(assert) {
         Buffer(frame.body.args[0]),
         'CallResponse.RW.lazy.readArg1');
 
+    // validate lazy header reading
+    var res = v2.CallResponse.RW.lazy.readHeaders(lazyFrame);
+    assert.ifError(res.err, 'no error from v2.CallResponse.RW.lazy.readHeaders');
+    var headers = res.value;
+    if (headers) {
+        // should fail fast because no key matches length 4
+        assert.equal(
+            headers.getValue(Buffer("nope")),
+            undefined,
+            'no "nope" header key');
+        // should fail slow since all keys have length 2, but none match
+        assert.equal(
+            headers.getValue(Buffer("no")),
+            undefined,
+            'no "no" header key');
+        // should have this one
+        assert.deepEqual(
+            headers.getValue(Buffer("as")),
+            Buffer('plumber'),
+            'expected header "as" => "plumber"');
+    }
+
     assert.end();
 
     function assertReadRes(res, value, desc) {

--- a/test/v2/lazy_frame.js
+++ b/test/v2/lazy_frame.js
@@ -170,6 +170,32 @@ test('CallRequest.RW.lazy', function t(assert) {
         !(frame.body.flags & v2.CallFlags.Fragment),
         'CallRequest.RW.lazy.isFrameTerminal');
 
+    // validate lazy header reading
+    var res = v2.CallRequest.RW.lazy.readHeaders(lazyFrame);
+    assert.ifError(res.err, 'no error from v2.CallRequest.RW.lazy.readHeaders');
+    var headers = res.value;
+    if (headers) {
+        // should fail fast because no key matches length 4
+        assert.equal(
+            headers.getValue(Buffer("nope")),
+            undefined,
+            'no "nope" header key');
+        // should fail slow since all keys have length 2, but none match
+        assert.equal(
+            headers.getValue(Buffer("no")),
+            undefined,
+            'no "no" header key');
+        // should have these two
+        assert.deepEqual(
+            headers.getValue(Buffer("cn")),
+            Buffer('mario'),
+            'expected header "cn" => "mario"');
+        assert.deepEqual(
+            headers.getValue(Buffer("as")),
+            Buffer('plumber'),
+            'expected header "as" => "plumber"');
+    }
+
     // validate call req lazy writing
     var newTTL = frame.body.ttl - 15;
     assert.ifError(

--- a/v2/call.js
+++ b/v2/call.js
@@ -98,6 +98,24 @@ CallRequest.RW.lazy.readService = function lazyReadService(frame) {
     return bufrw.str1.readFrom(frame.buffer, CallRequest.RW.lazy.serviceOffset);
 };
 
+CallRequest.RW.lazy.readHeaders = function readHeaders(frame) {
+    // last fixed offset
+    var offset = CallRequest.RW.lazy.serviceOffset;
+
+    // TODO: memoize computed offsets on frame between readService, readArg1,
+    // and any others
+
+    // SKIP service~1
+    var res = bufrw.str1.sizerw.readFrom(frame.buffer, offset);
+    if (res.err) {
+        return res;
+    }
+    offset = res.offset + res.value;
+
+    // READ nh:1 (hk~1 hv~1){nh}
+    return header.header1.lazyRead(frame, offset);
+};
+
 CallRequest.RW.lazy.readArg1 = function readArg1(frame) {
     // last fixed offset
     var offset = CallRequest.RW.lazy.serviceOffset;

--- a/v2/call.js
+++ b/v2/call.js
@@ -321,6 +321,17 @@ CallResponse.RW.lazy.readTracing = function lazyReadTracing(frame) {
 
 CallResponse.RW.lazy.headersOffset = CallResponse.RW.lazy.tracingOffset + 25;
 
+CallResponse.RW.lazy.readHeaders = function readHeaders(frame) {
+    // last fixed offset
+    var offset = CallResponse.RW.lazy.headersOffset;
+
+    // TODO: memoize computed offsets on frame between readService, readArg1,
+    // and any others
+
+    // READ nh:1 (hk~1 hv~1){nh}
+    return header.header1.lazyRead(frame, offset);
+};
+
 CallResponse.RW.lazy.readArg1 = function readArg1(frame) {
     // last fixed offset
     var offset = CallResponse.RW.lazy.headersOffset;


### PR DESCRIPTION
So that the upcoming stats path can get such things as the `cn` header.

r @Raynos @kriskowal 

Cheers @abhinav for making me think to use a typed array.