### PR TITLE
[as-http] add http <=> tchannel request response build latency stats

### DIFF
--- a/as/http.js
+++ b/as/http.js
@@ -334,8 +334,9 @@ TChannelHTTP.prototype.setHandler = function register(tchannel, handler) {
 
 TChannelHTTP.prototype.forwardToTChannel = function forwardToTChannel(tchannel, hreq, hres, requestOptions, callback) {
     var self = this;
-    var start = self.channel.timers.now();
+    self.channel = self.channel || tchannel;
     self.logger = self.logger || tchannel.logger;
+    var start = self.channel.timers.now();
     // TODO: more http state machine integration
 
     var options = tchannel.requestOptions(extendInto({

--- a/lib/stat.js
+++ b/lib/stat.js
@@ -58,7 +58,8 @@ module.exports = {
     ConnectionsAcceptErrorsTags: ConnectionsAcceptErrorsTags,
     ConnectionsErrorsTags: ConnectionsErrorsTags,
     ConnectionsClosedTags: ConnectionsClosedTags,
-    RelayLatencyTags: RelayLatencyTags
+    RelayLatencyTags: RelayLatencyTags,
+    HTTPHanlderBuildLatencyTags: HTTPHanlderBuildLatencyTags
 };
 
 function BaseStat(name, type, value, tags) {
@@ -774,4 +775,26 @@ function RelayLatencyTags() {
 
 RelayLatencyTags.prototype.toStatKey = function toStatKey(prefix) {
     return prefix;
+};
+
+function HTTPHanlderBuildLatencyTags(serviceName, callerName, streamed) {
+    var self = this;
+
+    self.app = '';
+    self.host = '';
+    self.cluster = '';
+    self.version = '';
+
+    self.targetService = serviceName;
+    self.callerName = callerName;
+    self.streamed = streamed;
+}
+
+HTTPHanlderBuildLatencyTags.prototype.toStatKey = function toStatKey(prefix) {
+    var self = this;
+
+    return prefix + '.' +
+        clean(self.callerName, 'no-caller-name') + '.' +
+        clean(self.targetService, 'no-target-service') + '.' +
+        self.streamed ? 'streamed' : 'unstreamed';
 };


### PR DESCRIPTION
the stats added are:
tchannel.outbound.http-handler.request-build-latency: http request -> tchannel request
tchannel.outbound.http-handler.response-build-latency: tchannel response -> http response
tchannel.inbound.http-handler.request-build-latency: tchannel request -> http request
tchannel.inbound.http-handler.response-build-latency: http response -> tchannel response
tchannel.inbound.http-handler.service-call-latency: http request -> http response

stats are tagged by callerName, targetName, type (streamed/unstreamed).

r: @jcorbin @Raynos @ShanniLi 
cc: @davewhat @vipulaneja 