### PR TITLE
Fix uncaught exception on request without connection

### DIFF
--- a/in_request.js
+++ b/in_request.js
@@ -82,7 +82,6 @@ TChannelInRequest.prototype.extendLogInfo = function extendLogInfo(info) {
     info.requestType = self.type;
     info.requestState = States.describe(self.state);
     info.requestRemoteAddr = self.remoteAddr;
-    info.socketRemoteAddr = self.connection.socketRemoteAddr;
     info.serviceName = self.serviceName;
     info.callerName = self.callerName;
     info.requestErr = self.err;


### PR DESCRIPTION
This has caused multiple uncaught exception in production since yesterday. The property in question is redundant with a property by the same name added by connection.extendLogInfo, on the condition that a connection is affiliated with the request.