### PR TITLE
Add ability to toggle lazy relaying separately from lazy handling

### DIFF
--- a/channel.js
+++ b/channel.js
@@ -117,6 +117,7 @@ function TChannel(options) {
 
     self.options = extend({
         useLazyHandling: false,
+        useLazyRelaying: false,
         timeoutCheckInterval: 100,
         timeoutFuzz: 100,
         connectionStalePeriod: CONN_STALE_PERIOD,
@@ -312,6 +313,25 @@ TChannel.prototype.setLazyHandling = function setLazyHandling(enabled) {
 
     function updateEachConn(conn) {
         conn.setLazyHandling(enabled);
+    }
+};
+
+TChannel.prototype.setLazyRelaying = function setLazyRelaying(enabled) {
+    var self = this;
+
+    if (self.topChannel) {
+        self.topChannel.setLazyRelaying(enabled);
+        return;
+    }
+
+    self.options.useLazyRelaying = enabled;
+
+    var keys = Object.keys(self.subChannels);
+    for (var i = 0; i < keys.length; i++) {
+        var subChan = self.subChannels[keys[i]];
+        if (subChan.handler.type === 'tchannel.relay-handler') {
+            subChan.handler.lazyEnabled = enabled;
+        }
     }
 };
 

--- a/channel.js
+++ b/channel.js
@@ -116,8 +116,8 @@ function TChannel(options) {
     self.connectionEvent = self.defineEvent('connection');
 
     self.options = extend({
-        useLazyHandling: false,
-        useLazyRelaying: false,
+        useLazyHandling: true,
+        useLazyRelaying: true,
         timeoutCheckInterval: 100,
         timeoutFuzz: 100,
         connectionStalePeriod: CONN_STALE_PERIOD,

--- a/relay_handler.js
+++ b/relay_handler.js
@@ -36,6 +36,7 @@ function RelayHandler(channel, circuits) {
     self.channel = channel;
     self.circuits = circuits || null;
     self.logger = self.channel.logger;
+    self.lazyEnabled = self.channel.options.useLazyRelaying;
 }
 
 RelayHandler.prototype.type = 'tchannel.relay-handler';
@@ -43,7 +44,9 @@ RelayHandler.prototype.type = 'tchannel.relay-handler';
 RelayHandler.prototype.handleLazily = function handleLazily(conn, reqFrame) {
     var self = this;
 
-    // TODO: provide a by-service-name config hook?
+    if (!self.lazyEnabled) {
+        return false;
+    }
 
     var rereq = new LazyRelayInReq(conn, reqFrame);
     var err = rereq.initRead();

--- a/test/relay_lazy.js
+++ b/test/relay_lazy.js
@@ -31,6 +31,7 @@ allocCluster.test('send lazy relay requests', {
     var two = cluster.channels[1];
 
     one.setLazyHandling(true);
+    one.setLazyRelaying(true);
     var oneToTwo = one.makeSubChannel({
         serviceName: 'two',
         peers: [two.hostPort]
@@ -80,6 +81,7 @@ allocCluster.test('send relay with tiny timeout', {
     var two = cluster.channels[1];
 
     one.setLazyHandling(true);
+    one.setLazyRelaying(true);
     var oneToTwo = one.makeSubChannel({
         serviceName: 'two',
         peers: [two.hostPort]
@@ -140,6 +142,7 @@ allocCluster.test('relay respects ttl', {
     var dest = cluster.channels[2];
 
     relay.setLazyHandling(true);
+    relay.setLazyRelaying(true);
     var relayChan = relay.makeSubChannel({
         serviceName: 'dest',
         peers: [dest.hostPort]
@@ -193,6 +196,7 @@ allocCluster.test('relay an error frame', {
     var four = cluster.channels[3];
 
     one.setLazyHandling(true);
+    one.setLazyRelaying(true);
     var oneToTwo = one.makeSubChannel({
         serviceName: 'two',
         peers: [two.hostPort, three.hostPort]
@@ -203,6 +207,7 @@ allocCluster.test('relay an error frame', {
          assert, 'handle requests eagerly');
 
     four.setLazyHandling(true);
+    four.setLazyRelaying(true);
     var fourToTwo = four.makeSubChannel({
         serviceName: 'two',
         peers: [two.hostPort, three.hostPort]
@@ -262,6 +267,7 @@ allocCluster.test('relay request times out', {
     var dest = cluster.channels[2];
 
     relay.setLazyHandling(true);
+    relay.setLazyRelaying(true);
     var relayChan = relay.makeSubChannel({
         serviceName: 'dest',
         peers: [dest.hostPort]
@@ -324,6 +330,7 @@ allocCluster.test('relay request declines on no peer', {
     var source = cluster.channels[1];
 
     relay.setLazyHandling(true);
+    relay.setLazyRelaying(true);
     var relayChan = relay.makeSubChannel({
         serviceName: 'dest',
         peers: []
@@ -369,6 +376,7 @@ allocCluster.test('relay request handles channel close correctly', {
     var dest = cluster.channels[2];
 
     relay.setLazyHandling(true);
+    relay.setLazyRelaying(true);
     var relayChan = relay.makeSubChannel({
         serviceName: 'dest',
         peers: [dest.hostPort]


### PR DESCRIPTION
Problem:
- we can turn lazy relaying on without incident
- but we cannot turn it off without a low defect rate

Why:
- lazy handling gets flipped only at the frame reading level currently
- however there are on going lazy requests at the time of flip off
- flipping immediately back to "eager only" frames breaks the ongoing handling of those requests

Solution:
- [x] introduce a separate control point within `RelayHandler#handleLazily` that allows us to stop creating new lazy relay requests
- [ ] once there are no more ongoing lazy relay requests, we can then turn off lazy frame reading

cc @Raynos @kriskowal @rf 