### PR TITLE
Shorten path between LazyInReq and LazyOutReq

### DIFF
--- a/relay_handler.js
+++ b/relay_handler.js
@@ -272,7 +272,12 @@ function createOutRequest() {
         return;
     }
 
-    self.peer.waitForIdentified(self.boundOnIdentified);
+    var conn = chooseRelayPeerConnection(self.peer);
+    if (conn && conn.remoteName && !conn.closing) {
+        self.forwardTo(conn);
+    } else {
+        self.peer.waitForIdentified(self.boundOnIdentified);
+    }
 };
 
 LazyRelayInReq.prototype.onIdentified =

--- a/relay_handler.js
+++ b/relay_handler.js
@@ -294,6 +294,13 @@ function onIdentified(err) {
         self.logger.warn('onIdentified called on closing connection', self.extendLogInfo({}));
     }
 
+    self.forwardTo(conn);
+};
+
+LazyRelayInReq.prototype.forwardTo =
+function forwardTo(conn) {
+    var self = this;
+
     self.outreq = new LazyRelayOutReq(conn, self);
 
     var ttl = self.updateTTL(self.outreq.start);


### PR DESCRIPTION
By explicit branching and rarely calling `peer.waitForIdentified`.

r @Raynos @rf 