### PR TITLE
v2/args: fix subtlety in recent args string fix

### DIFF
--- a/v2/args.js
+++ b/v2/args.js
@@ -170,8 +170,7 @@ ArgsRW.prototype.writeFragmentInto = function writeFragmentInto(body, buffer, of
 
     do {
         var arg = body.args[i] || Buffer(0);
-        if (!Buffer.isBuffer(arg) &&
-            buffer.length < offset + Buffer.byteLength(arg, 'utf8')) {
+        if (!Buffer.isBuffer(arg)) {
             arg = new Buffer(arg);
         }
         var min = self.overhead + arg.length ? 1 : 0;


### PR DESCRIPTION
Out of #68:
- this length check wasn't just not needed...
- ...it's also potentially harmful since if the arg is long enough to overflow a frame, it will continue to not get chunked correctly

r @ShanniLi @Raynos 