### PR TITLE
& only works on numbers

### DIFF
--- a/v2/call.js
+++ b/v2/call.js
@@ -157,7 +157,7 @@ CallRequest.RW.lazy.readArg1 = function readArg1(frame, headers) {
 
 CallRequest.RW.lazy.isFrameTerminal = function isFrameTerminal(frame) {
     var flags = CallRequest.RW.lazy.readFlags(frame);
-    var frag = flags & CallFlags.Fragment;
+    var frag = flags.value & CallFlags.Fragment;
     return !frag;
 };
 
@@ -373,7 +373,7 @@ CallResponse.RW.lazy.readArg1 = function readArg1(frame, headers) {
 
 CallResponse.RW.lazy.isFrameTerminal = function isFrameTerminal(frame) {
     var flags = CallResponse.RW.lazy.readFlags(frame);
-    var frag = flags & CallFlags.Fragment;
+    var frag = flags.value & CallFlags.Fragment;
     return !frag;
 };
 

--- a/v2/cont.js
+++ b/v2/cont.js
@@ -51,7 +51,7 @@ CallRequestCont.RW.lazy.readFlags = function readFlags(frame) {
 
 CallRequestCont.RW.lazy.isFrameTerminal = function isFrameTerminal(frame) {
     var flags = CallRequestCont.RW.lazy.readFlags(frame);
-    var frag = flags & CallFlags.Fragment;
+    var frag = flags.value & CallFlags.Fragment;
     return !frag;
 };
 
@@ -134,7 +134,7 @@ CallResponseCont.RW.lazy.readFlags = function readFlags(frame) {
 
 CallResponseCont.RW.lazy.isFrameTerminal = function isFrameTerminal(frame) {
     var flags = CallResponseCont.RW.lazy.readFlags(frame);
-    var frag = flags & CallFlags.Fragment;
+    var frag = flags.value & CallFlags.Fragment;
     return !frag;
 };
 


### PR DESCRIPTION
We forgot to unwrap the Result object which broke
all fragmented things in production.

r: @rf @jcorbin