### PR TITLE
allocCluster: support TCHANNEL_TEST_CONFIG

### DIFF
--- a/test/lib/alloc-cluster.js
+++ b/test/lib/alloc-cluster.js
@@ -20,6 +20,7 @@
 
 'use strict';
 
+var fs = require('fs');
 var extend = require('xtend');
 var CountedReadySignal = require('ready-signal/counted');
 var test = require('tape');
@@ -29,6 +30,24 @@ var debugLogtron = require('debug-logtron');
 
 var TChannel = require('../../channel.js');
 var CollapsedAssert = require('./collapsed-assert.js');
+
+var defaultChannelOptions = {};
+if (process.env.TCHANNEL_TEST_CONFIG) {
+    defaultChannelOptions = JSON.parse(
+        fs.readFileSync(process.env.TCHANNEL_TEST_CONFIG, 'utf8'));
+    JSON.stringify(defaultChannelOptions, null, 4)
+        .split('\n')
+        .forEach(function each(line, i) {
+            if (i === 0) {
+                console.log(
+                    '# allocCluster using default channel config from %s: %s',
+                    process.env.TCHANNEL_TEST_CONFIG,
+                    line);
+            } else {
+                console.log('# %s', line);
+            }
+        });
+}
 
 module.exports = allocCluster;
 
@@ -57,7 +76,7 @@ function allocCluster(opts) {
         logger: logger,
         timeoutFuzz: 0,
         traceSample: 1
-    }, opts.channelOptions || opts);
+    }, defaultChannelOptions, opts.channelOptions || opts);
 
     for (var i = 0; i < opts.numPeers; i++) {
         createChannel(i);


### PR DESCRIPTION
This allows parameterized test-suite runs, e.g.:
```
$ cat such_config.json
{
  "choosePeerWithHeap": true
}

$ TCHANNEL_TEST_CONFIG=such_config.json node test
# allocCluster using default channel config from such_config.json: {
#     "choosePeerWithHeap": true
# }
TAP version 13
# errors module should be in sorted order
ok 1 errors module is in sorted order
# error classification cases must be sorted
ok 2 Cancelled cases are in sorted order
ok 3 Declined cases are in sorted order
...
ok 2772 request() has response
ok 2773 response is ok
ok 2774 response body is 10

1..2774
# tests 2774
# pass  2725
# fail  49
```

To start iterating on the peer heap feature; a similar run can be done for lazy relaying.

r @Raynos 