### PR TITLE
TChannel: ensure that close callback does not early fire

### DIFF
--- a/channel.js
+++ b/channel.js
@@ -891,7 +891,10 @@ TChannel.prototype.close = function close(callback) {
         self.timers.clearTimeout(self.batchStatTimer);
     }
 
+    counter++;
     self.peers.close(onClose);
+
+    onClose();
 
     function closeServerSocket() {
         self.serverSocket.once('close', onClose);


### PR DESCRIPTION
While chasing #31, I noticed that there was room for pre-mature callback out of `TChannel#close`.

r @abhinav 