### PR TITLE
connection: refactor sendLazyErrorFrame into 2 methods

### DIFF
--- a/connection.js
+++ b/connection.js
@@ -691,13 +691,21 @@ InitOperation.prototype.onTimeout = function onTimeout(now) {
     self.connection.resetAll(err);
 };
 
-TChannelConnection.prototype.sendLazyErrorFrame =
-function sendLazyErrorFrame(reqFrame, codeString, message) {
+TChannelConnection.prototype.sendLazyErrorFrameForReq =
+function sendLazyErrorFrameForReq(reqFrame, codeString, message) {
     var self = this;
 
     var res = reqFrame.bodyRW.lazy.readTracing(reqFrame);
     var tracing = res.err ? v2.Tracing.emptyTracing : res.value;
-    self.handler.sendErrorFrame(reqFrame.id, tracing, codeString, message);
+
+    self.sendLazyErrorFrame(reqFrame.id, tracing, codeString, message);
+};
+
+TChannelConnection.prototype.sendLazyErrorFrame =
+function sendLazyErrorFrame(id, tracing, codeString, message) {
+    var self = this;
+
+    self.handler.sendErrorFrame(id, tracing, codeString, message);
 };
 
 TChannelConnection.prototype._drain =

--- a/relay_handler.js
+++ b/relay_handler.js
@@ -375,7 +375,7 @@ function onError(err) {
 LazyRelayInReq.prototype.sendErrorFrame =
 function sendErrorFrame(codeName, message) {
     var self = this;
-    self.conn.sendLazyErrorFrame(self.reqFrame, codeName, message);
+    self.conn.sendLazyErrorFrameForReq(self.reqFrame, codeName, message);
 };
 
 LazyRelayInReq.prototype.handleFrameLazily =

--- a/service-name-handler.js
+++ b/service-name-handler.js
@@ -52,7 +52,7 @@ TChannelServiceNameHandler.prototype.handleLazily = function handleLazily(conn, 
             error: res.err
         }));
         // TODO: protocol error instead?
-        conn.sendLazyErrorFrame(reqFrame, 'BadRequest', 'failed to read serviceName');
+        conn.sendLazyErrorFrameForReq(reqFrame, 'BadRequest', 'failed to read serviceName');
         return false;
     }
 
@@ -61,7 +61,7 @@ TChannelServiceNameHandler.prototype.handleLazily = function handleLazily(conn, 
         // TODO: reqFrame.extendLogInfo would be nice, especially if it added
         // things like callerName and arg1
         self.channel.logger.warn('missing service name in lazy frame', conn.extendLogInfo({}));
-        conn.sendLazyErrorFrame(reqFrame, 'BadRequest', 'missing serviceName');
+        conn.sendLazyErrorFrameForReq(reqFrame, 'BadRequest', 'missing serviceName');
         return false;
     }
 


### PR DESCRIPTION
r @jcorbin @Raynos 

Refactor `sendLazyErrorFrame` into one that takes `id` and `tracing` and one that takes a `reqFrame`