### PR TITLE
Better hyperbahn link test

### DIFF
--- a/hyperbahn_link_test.sh
+++ b/hyperbahn_link_test.sh
@@ -2,7 +2,7 @@
 set -e
 
 if [ -z "$1" ]; then
-    dest_dir=$(mktemp -d)
+    dest_dir=$(mktemp -d -t tchannel.XXXXXX)
     git clone https://github.com/uber/hyperbahn "$dest_dir"
 else
     dest_dir=$1

--- a/hyperbahn_link_test.sh
+++ b/hyperbahn_link_test.sh
@@ -1,4 +1,25 @@
 #!/bin/bash
+
+# Copyright (c) 2015 Uber Technologies, Inc.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
 set -e
 
 if [ -z "$1" ]; then

--- a/hyperbahn_link_test.sh
+++ b/hyperbahn_link_test.sh
@@ -1,11 +1,17 @@
 #!/bin/bash
 set -e
 
+if [ -z "$1" ]; then
+    dest_dir=$(mktemp -d)
+    git clone https://github.com/uber/hyperbahn "$dest_dir"
+else
+    dest_dir=$1
+fi
+
 npm link
 
-cd "$(mktemp -d)"
+cd "$dest_dir"
 
-git clone https://github.com/uber/hyperbahn .
 npm install
 npm link tchannel
 npm run test-ci

--- a/hyperbahn_link_test.sh
+++ b/hyperbahn_link_test.sh
@@ -9,9 +9,11 @@ else
 fi
 
 if [ -n "$TCHANNEL_TEST_CONFIG" ]; then
-    dest_tchannel_test_config="$dest_dir/from_tchannel_$(echo "$TCHANNEL_TEST_CONFIG" | tr '/' '_')"
-    cp -fv "$TCHANNEL_TEST_CONFIG" "$dest_tchannel_test_config"
-    TCHANNEL_TEST_CONFIG=$(basename "$dest_tchannel_test_config")
+    for part in $(eval "echo $TCHANNEL_TEST_CONFIG"); do
+        dest_part="$dest_dir/from_tchannel_$(echo "$part" | tr '/' '_')"
+        cp -fv "$part" "$dest_part"
+    done
+    TCHANNEL_TEST_CONFIG=from_tchannel_$(echo "$TCHANNEL_TEST_CONFIG" | tr '/' '_')
     export TCHANNEL_TEST_CONFIG
 fi
 

--- a/hyperbahn_link_test.sh
+++ b/hyperbahn_link_test.sh
@@ -8,6 +8,13 @@ else
     dest_dir=$1
 fi
 
+if [ -n "$TCHANNEL_TEST_CONFIG" ]; then
+    dest_tchannel_test_config="$dest_dir/from_tchannel_$(echo "$TCHANNEL_TEST_CONFIG" | tr '/' '_')"
+    cp -fv "$TCHANNEL_TEST_CONFIG" "$dest_tchannel_test_config"
+    TCHANNEL_TEST_CONFIG=$(basename "$dest_tchannel_test_config")
+    export TCHANNEL_TEST_CONFIG
+fi
+
 npm link
 
 cd "$dest_dir"

--- a/hyperbahn_link_test.sh
+++ b/hyperbahn_link_test.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+set -e
+
+npm link
+
+cd "$(mktemp -d)"
+
+git clone https://github.com/uber/hyperbahn .
+npm install
+npm link tchannel
+npm run test-ci

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "travis": "npm run test",
     "test": "npm run check-licence && npm run lint -s && npm run cover -s && npm run check-benchmark -s",
     "benchmark": "echo '!!! DEPRECATED: Better to just run `node benchmarks` directly' >&2; node benchmarks",
-    "hyperbahn-link-test": "npm link && cd $(mktemp -d) && git clone https://github.com/uber/hyperbahn . && npm install && npm link tchannel && npm run test-ci",
+    "hyperbahn-link-test": "./hyperbahn_link_test.sh",
     "check-benchmark": "node benchmarks -- -r 10000 -p 10000",
     "take-benchmark": "make -C benchmarks take",
     "take-relay-benchmark": "make -C benchmarks take_relay",


### PR DESCRIPTION
Now supports:
- easy local run against existing hyperbahn checkout
- copies any $TCHANNEL_TEST_CONFIG to the destination hyperbahn to avoid ENOENT problem since `npm run ...` does a chdir to the destination dir

r @rf @abhinav 