### PR TITLE
TChannelPeer: drop closure around connection handling

### DIFF
--- a/peer.js
+++ b/peer.js
@@ -355,24 +355,30 @@ TChannelPeer.prototype.addConnection = function addConnection(conn) {
         conn.closeEvent.removeListener(onConnectionClose);
         conn.errorEvent.removeListener(onConnectionError);
         conn.identifiedEvent.removeListener(onIdentified);
-        if (err) {
-            var loggerInfo = {
-                error: err,
-                direction: conn.direction,
-                remoteName: conn.remoteName,
-                socketRemoteAddr: conn.socketRemoteAddr
-            };
-
-            var codeName = errors.classify(err);
-            if (codeName === 'Timeout') {
-                self.logger.warn('Got a connection error', loggerInfo);
-            } else {
-                self.logger.error('Got an unexpected connection error', loggerInfo);
-            }
-        }
-
-        self.removeConnection(conn);
+        self.removeConnectionFrom(err, conn);
     }
+};
+
+TChannelPeer.prototype.removeConnectionFrom =
+function removeConnectionFrom(err, conn) {
+    var self = this;
+
+    if (err) {
+        var loggerInfo = {
+            error: err,
+            direction: conn.direction,
+            remoteName: conn.remoteName,
+            socketRemoteAddr: conn.socketRemoteAddr
+        };
+        var codeName = errors.classify(err);
+        if (codeName === 'Timeout') {
+            self.logger.warn('Got a connection error', loggerInfo);
+        } else {
+            self.logger.error('Got an unexpected connection error', loggerInfo);
+        }
+    }
+
+    self.removeConnection(conn);
 };
 
 TChannelPeer.prototype.removeConnection = function removeConnection(conn) {

--- a/peer.js
+++ b/peer.js
@@ -344,18 +344,17 @@ TChannelPeer.prototype.addConnection = function addConnection(conn) {
     }
 
     function onConnectionError(err) {
-        removeConnection(err);
-    }
-
-    function onConnectionClose() {
-        removeConnection(null);
-    }
-
-    function removeConnection(err) {
         conn.closeEvent.removeListener(onConnectionClose);
         conn.errorEvent.removeListener(onConnectionError);
         conn.identifiedEvent.removeListener(onIdentified);
         self.removeConnectionFrom(err, conn);
+    }
+
+    function onConnectionClose() {
+        conn.closeEvent.removeListener(onConnectionClose);
+        conn.errorEvent.removeListener(onConnectionError);
+        conn.identifiedEvent.removeListener(onIdentified);
+        self.removeConnectionFrom(null, conn);
     }
 };
 

--- a/peer.js
+++ b/peer.js
@@ -36,6 +36,8 @@ var PreferIncoming = require('./peer_score_strategies.js').PreferIncoming;
 var DEFAULT_REPORT_INTERVAL = 1000;
 
 function TChannelPeer(channel, hostPort, options) {
+    assert(hostPort !== '0.0.0.0:0', 'Cannot create ephemeral peer');
+
     if (!(this instanceof TChannelPeer)) {
         return new TChannelPeer(channel, hostPort, options);
     }
@@ -46,9 +48,6 @@ function TChannelPeer(channel, hostPort, options) {
     self.stateChangedEvent = self.defineEvent('stateChanged');
     self.allocConnectionEvent = self.defineEvent('allocConnection');
     self.removeConnectionEvent = self.defineEvent('removeConnection');
-
-    assert(hostPort !== '0.0.0.0:0', 'Cannot create ephemeral peer');
-
     self.channel = channel;
     self.logger = self.channel.logger;
     self.timers = self.channel.timers;


### PR DESCRIPTION
Re-use the constructor closure instead.

r @Raynos @kriskowal 