### PR TITLE
Add peer score debugging support, use it in test/pool-of-servers

### DIFF
--- a/channel.js
+++ b/channel.js
@@ -114,6 +114,8 @@ function TChannel(options) {
     self.errorEvent = self.defineEvent('error');
     self.listeningEvent = self.defineEvent('listening');
     self.connectionEvent = self.defineEvent('connection');
+    self.peerChosenEvent = null;
+    self.peerScoredEvent = null;
 
     self.options = extend({
         useLazyHandling: false,
@@ -136,6 +138,8 @@ function TChannel(options) {
         typeof self.options.emitConnectionMetrics === 'boolean' ?
         self.options.emitConnectionMetrics : false;
     self.choosePeerWithHeap = self.options.choosePeerWithHeap || false;
+
+    self.setObservePeerScoreEvents(self.options.observePeerScoreEvents);
 
     // required: 'app'
     // optional: 'host', 'cluster', 'version'
@@ -300,6 +304,19 @@ TChannel.prototype.eachConnection = function eachConnection(each) {
         for (i = 0; i < connKeys.length; i++) {
             each(self.serverConnections[connKeys[i]]);
         }
+    }
+};
+
+TChannel.prototype.setObservePeerScoreEvents =
+function setObservePeerScoreEvents(obs) {
+    var self = this;
+
+    if (obs) {
+        self.peerChosenEvent = self.defineEvent('peerChosen');
+        self.peerScoredEvent = self.defineEvent('peerScored');
+    } else {
+        self.peerChosenEvent = null;
+        self.peerScoredEvent = null;
     }
 };
 

--- a/connection_base.js
+++ b/connection_base.js
@@ -137,7 +137,7 @@ function connBaseRequest(options) {
         req.drainReason = self.drainReason;
     }
     self.ops.addOutReq(req);
-    req.peer.invalidateScore();
+    req.peer.invalidateScore('conn.request');
     return req;
 };
 

--- a/out_request.js
+++ b/out_request.js
@@ -233,7 +233,7 @@ TChannelOutRequest.prototype.emitError = function emitError(err) {
     self.emitPerAttemptLatency();
     self.emitPerAttemptErrorStat(err);
 
-    self.peer.invalidateScore();
+    self.peer.invalidateScore('outreq.emitError');
 
     self.errorEvent.emit(self, err);
 };
@@ -260,7 +260,7 @@ TChannelOutRequest.prototype.extendLogInfo = function extendLogInfo(info) {
 TChannelOutRequest.prototype.emitResponse = function emitResponse(res) {
     var self = this;
 
-    self.peer.invalidateScore();
+    self.peer.invalidateScore('outreq.emitResponse');
 
     if (self.end) {
         self.channel.logger.warn('Unexpected response after end for OutRequest', {

--- a/peer.js
+++ b/peer.js
@@ -142,17 +142,33 @@ TChannelPeer.prototype.setScoreStrategy = function setScoreStrategy(ScoreStrateg
     self.handler = new ScoreStrategy(self);
 };
 
-TChannelPeer.prototype.invalidateScore = function invalidateScore() {
+TChannelPeer.prototype.invalidateScore = function invalidateScore(reason) {
     var self = this;
 
     if (!self.heapElements.length) {
         return;
     }
 
+    var info = self.channel.peerScoredEvent ? {
+        peer: self,
+        reason: reason || 'unknown',
+        score: 0,
+        oldScores: [],
+        scores: []
+    } : null;
+
     var score = self.handler.getScore();
     for (var i = 0; i < self.heapElements.length; i++) {
         var el = self.heapElements[i];
+        if (info) {
+            info.oldScores.push(el.score);
+            info.scores.push(score);
+        }
         el.rescore(score);
+    }
+
+    if (info) {
+        self.channel.peerScoredEvent.emit(self, info);
     }
 };
 

--- a/peer.js
+++ b/peer.js
@@ -133,7 +133,7 @@ TChannelPeer.prototype.setPreferConnectionDirection = function setPreferConnecti
         self.setScoreStrategy(NoPreference);
     }
 
-    self.invalidateScore();
+    self.invalidateScore('setPreferConnectionDirection');
 };
 
 TChannelPeer.prototype.setScoreStrategy = function setScoreStrategy(ScoreStrategy) {
@@ -302,7 +302,7 @@ function _waitForIdentified(conn, callback) {
     conn.errorEvent.on(onConnectionError);
     conn.closeEvent.on(onConnectionClose);
     conn.identifiedEvent.on(onIdentified);
-    self.invalidateScore();
+    self.invalidateScore('waitForIdentified');
 
     function onConnectionError(err) {
         finish(err);
@@ -321,7 +321,7 @@ function _waitForIdentified(conn, callback) {
         conn.errorEvent.removeListener(onConnectionError);
         conn.closeEvent.removeListener(onConnectionClose);
         conn.identifiedEvent.removeListener(onIdentified);
-        self.invalidateScore();
+        self.invalidateScore('waitForIdentified > finish');
         callback(err);
     }
 };
@@ -344,7 +344,7 @@ TChannelPeer.prototype.addConnection = function addConnection(conn) {
     conn.errorEvent.on(self.boundOnConnectionError);
     conn.closeEvent.on(self.boundOnConnectionClose);
 
-    self._maybeInvalidateScore();
+    self._maybeInvalidateScore('addConnection');
     if (!conn.remoteName) {
         // TODO: could optimize if handler had a way of saying "would a new
         // identified connection change your Tier?"
@@ -359,7 +359,7 @@ function onIdentified(conn) {
     var self = this;
 
     conn.identifiedEvent.removeListener(self.boundOnIdentified);
-    self._maybeInvalidateScore();
+    self._maybeInvalidateScore('addConnection > onIdentified');
 };
 
 TChannelPeer.prototype.onConnectionError =
@@ -414,7 +414,7 @@ TChannelPeer.prototype.removeConnection = function removeConnection(conn) {
         ret = self.connections.splice(index, 1)[0];
     }
 
-    self._maybeInvalidateScore();
+    self._maybeInvalidateScore('removeConnection');
 
     self.removeConnectionEvent.emit(self, conn);
     return ret;
@@ -493,11 +493,12 @@ TChannelPeer.prototype.countPending = function countPending() {
 // - on identified
 
 // Called on connection change event
-TChannelPeer.prototype._maybeInvalidateScore = function _maybeInvalidateScore() {
+TChannelPeer.prototype._maybeInvalidateScore =
+function _maybeInvalidateScore(reason) {
     var self = this;
 
     if (self.handler.getTier() !== self.handler.lastTier) {
-        self.invalidateScore();
+        self.invalidateScore(reason);
     }
 };
 

--- a/test/lib/barplot.js
+++ b/test/lib/barplot.js
@@ -1,0 +1,61 @@
+// Copyright (c) 2015 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+'use strict';
+
+module.exports = barplot;
+
+function barplot(emit, pairs) {
+    var key, i;
+
+    var maxKeyLen = 0;
+    for (i = 0; i < pairs.length; i++) {
+        key = pairs[i][0];
+        var keyLen = pairs[i][0].length;
+        if (keyLen > maxKeyLen) {
+            maxKeyLen = keyLen;
+        }
+    }
+
+    maxKeyLen++;
+    for (i = 0; i < pairs.length; i++) {
+        key = pairs[i][0];
+        var count = pairs[i][1];
+        var countStr = 'count=' + count.toString();
+        emit(pad(maxKeyLen, ' ', key) +
+             pad(10, ' ', countStr) +
+             mulchr(count, '*'));
+    }
+}
+
+function pad(n, c, s) {
+    while (s.length < n) {
+        s += c;
+    }
+    return s;
+}
+
+function mulchr(n, c) {
+    var s = '';
+    while (s.length < n) {
+        s += c;
+    }
+    return s;
+}

--- a/test/lib/peer_score_obs.js
+++ b/test/lib/peer_score_obs.js
@@ -1,0 +1,69 @@
+// Copyright (c) 2015 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+'use strict';
+
+var format = require('util').format;
+
+module.exports = hookupPeerScoreObs;
+
+function hookupPeerScoreObs(log, client, servers) {
+    client.peerScoredEvent.on(onPeerScored);
+    client.peerChosenEvent.on(onPeerChosen);
+
+    function onPeerScored(info) {
+        var peerDesc = describeServerPeer(servers, info.peer);
+        var mess = format('%s scored peer %s', info.reason, peerDesc);
+        if (info.scores) {
+            var changes = info.scores.map(function each(score, i) {
+                var change = score / info.oldScores[i] - 1;
+                var sign = change > 0 ? '+' : '';
+                var str = sign + (100 * change).toFixed(1);
+                return pad(5, ' ', str) + '%';
+            });
+            mess += ' by ' + changes.join(', ') ;
+        } else {
+            mess += ' score=' + info.score;
+        }
+        log(mess);
+    }
+
+    function onPeerChosen(info) {
+        var peerDesc = describeServerPeer(servers, info.peer);
+        var mess = format('%s chose server %s', info.mode, peerDesc);
+        log(mess);
+    }
+}
+
+function describeServerPeer(servers, peer) {
+    for (var i = 0; i < servers.length; i++) {
+        if (peer.hostPort === servers[i].hostPort) {
+            return '' + (i + 1);
+        }
+    }
+    return 'unknown(' + peer.hostPort + ')';
+}
+
+function pad(n, c, s) {
+    while (s.length < n) {
+        s = c + s;
+    }
+    return s;
+}


### PR DESCRIPTION
- add reason strings to all score invalidations
- peer score and choice observation events and test library
- optional hookup of new observation path in test/pool-of-servers
- optional bar plot the distribution in test/pool-of-servers