### PR TITLE
ThriftRW v2.5.1

### DIFF
--- a/as/thrift.js
+++ b/as/thrift.js
@@ -206,8 +206,6 @@ function register(channel, name, opts, handle, spec) {
                     'expected response.body to exist');
 
                 if (!thriftRes.ok) {
-                    assert(isError(thriftRes.body),
-                        'not-ok body should be an error');
                     assert(typeof thriftRes.typeName === 'string',
                         'expected not-ok response to have typeName');
                 }

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "safe-json-parse": "^4.0.0",
     "sse4_crc32": "3.2.0",
     "tape-cluster": "2.1.0",
-    "thriftrw": "2.5.0",
+    "thriftrw": "2.5.1",
     "uber-statsd-client": "1.3.2",
     "xtend": "^4.0.0"
   },


### PR DESCRIPTION
- This change comes with a relaxation in ThriftRW to allow sets to be expressed as lists on the wire to ease migration where the old bug is present,
- Relaxed the requirement in TChannelAsThrift that application errors be instances of Error.
- Thrift exception instances are no longer Error instances. The specialization was unhelpful, complicated, and slow.