### PR TITLE
Make TChannelPeer more easily inspectable

### DIFF
--- a/peer.js
+++ b/peer.js
@@ -22,6 +22,7 @@
 
 var assert = require('assert');
 var inherits = require('util').inherits;
+var inspect = require('util').inspect;
 var EventEmitter = require('./lib/event_emitter');
 var stat = require('./lib/stat.js');
 var net = require('net');
@@ -113,6 +114,18 @@ function TChannelPeer(channel, hostPort, options) {
 }
 
 inherits(TChannelPeer, EventEmitter);
+
+TChannelPeer.prototype.toString =
+function toString() {
+    var self = this;
+    return 'TChannelPeer(' + self.hostPort + ')';
+};
+
+TChannelPeer.prototype.inspect =
+function inspectPeer() {
+    var self = this;
+    return 'TChannelPeer(' + inspect(self.extendLogInfo({})) + ')';
+};
 
 TChannelPeer.prototype.extendLogInfo =
 function extendLogInfo(info) {


### PR DESCRIPTION
Starting a new pattern of adding `#toString` and `#inspect` to our objects for easier debugging.

Makes it very easy to do things like `console.log(peers.toString())` for a short `TChannelPeer(X:Y), TChannelPeer(X1:Y2),...`.