### PR TITLE
TChannelPeer: fix draining for incoming connections

### DIFF
--- a/peer.js
+++ b/peer.js
@@ -397,6 +397,14 @@ TChannelPeer.prototype.addConnection = function addConnection(conn) {
         conn.identifiedEvent.on(self.boundOnIdentified);
     }
 
+    if (!conn.draining) {
+        if (conn.channel.draining) {
+            conn.drain(conn.channel.drainReason, null);
+        } else if (self.draining) {
+            conn.drain(self.drainReason, null);
+        }
+    }
+
     return conn;
 };
 
@@ -482,13 +490,6 @@ TChannelPeer.prototype.makeOutConnection = function makeOutConnection(socket) {
     var self = this;
     var chan = self.channel.topChannel || self.channel;
     var conn = new TChannelConnection(chan, socket, 'out', self.hostPort);
-
-    if (chan.draining) {
-        conn.drain(chan.drainReason, null);
-    } else if (self.draining) {
-        conn.drain(self.drainReason, null);
-    }
-
     self.allocConnectionEvent.emit(self, conn);
     return conn;
 };

--- a/test/chan_drain.js
+++ b/test/chan_drain.js
@@ -661,7 +661,7 @@ function setupTestClients(cluster, services, callback) {
     function ided(err, res) {
         for (var i = 0; i < res.length; i++) {
             if (res[i].err) {
-                callback(err, clients);
+                callback(res[i].err, clients);
                 return;
             }
         }

--- a/test/chan_drain.js
+++ b/test/chan_drain.js
@@ -635,7 +635,6 @@ allocCluster.test('chan.drain client with a few outgoing (with exempt service)',
 });
 
 // TODO: test draining of outgoing reqs
-// TODO: currently the exempt test provokes mismatched onReqDone callback warn logs
 
 function setupTestClients(cluster, services, callback) {
     var i;

--- a/test/peer_drain.js
+++ b/test/peer_drain.js
@@ -569,7 +569,7 @@ function setupTestClients(cluster, services, callback) {
     function ided(err, res) {
         for (var i = 0; i < res.length; i++) {
             if (res[i].err) {
-                callback(err, clients);
+                callback(res[i].err, clients);
                 return;
             }
         }

--- a/test/peer_drain.js
+++ b/test/peer_drain.js
@@ -543,7 +543,6 @@ allocCluster.test('drain client with a few outgoing (with exempt service)', {
 });
 
 // TODO: test draining of outgoing reqs
-// TODO: currently the exempt test provokes mismatched onReqDone callback warn logs
 
 function setupTestClients(cluster, services, callback) {
     var i;


### PR DESCRIPTION
Previously we weren't calling drain on new incoming connections.