### PR TITLE
Add directional support to `peer.drain`

### DIFF
--- a/peer.js
+++ b/peer.js
@@ -234,6 +234,34 @@ TChannelPeer.prototype.isConnected = function isConnected(direction, identified)
     return false;
 };
 
+TChannelPeer.prototype.closeDrainedConnections =
+function closeDrainedConnections(callback) {
+    var self = this;
+
+    var counter = 1;
+    var conns = self.connections.slice(0);
+
+    for (var i = 0; i < conns.length; i++) {
+        var conn = conns[i];
+        if (conn.draining) {
+            counter++;
+            conn.close(onClose);
+        }
+    }
+    onClose();
+
+    function onClose() {
+        if (--counter <= 0) {
+            if (counter < 0) {
+                self.logger.error('closed more peer sockets than expected', {
+                    counter: counter
+                });
+            }
+            callback(null);
+        }
+    }
+};
+
 TChannelPeer.prototype.close = function close(callback) {
     var self = this;
 

--- a/peer.js
+++ b/peer.js
@@ -341,10 +341,13 @@ TChannelPeer.prototype.connectTo = function connectTo() {
 };
 
 TChannelPeer.prototype.waitForIdentified =
-function waitForIdentified(callback) {
+function waitForIdentified(conn, callback) {
     var self = this;
 
-    var conn = self.connect();
+    if (typeof conn === 'function' && !callback) {
+        callback = conn;
+        conn = self.connect();
+    }
 
     if (conn.closing) {
         callback(conn.closeError);

--- a/peer.js
+++ b/peer.js
@@ -169,6 +169,15 @@ function drain(options, callback) {
     }
 };
 
+TChannelPeer.prototype.clearDrain =
+function clearDrain() {
+    var self = this;
+
+    self.draining = false;
+    self.drainReason = '';
+    self.drainDirection = '';
+};
+
 TChannelPeer.prototype.setPreferConnectionDirection = function setPreferConnectionDirection(direction) {
     var self = this;
     if (self.preferConnectionDirection === direction) {


### PR DESCRIPTION
Especially check out the tests, they essentially implement the "N + 1 connection pruning" we want in hyperbahn; one test is server side prune, other test is client side prune.

r @rf @Raynos 