### PR TITLE
WIP: errors.logLevel: downgrade ProtocolError to warn

### DIFF
--- a/errors.js
+++ b/errors.js
@@ -860,12 +860,14 @@ module.exports.isFatal = function isFatal(err, codeName) {
 
 module.exports.logLevel = function errorLogLevel(err, codeName) {
     switch (codeName) {
-        case 'ProtocolError':
         case 'UnexpectedError':
             if (err.isErrorFrame) {
                 return 'warn';
             }
             return 'error';
+
+        case 'ProtocolError':
+            return 'warn';
 
         case 'Busy':
         case 'Cancelled':


### PR DESCRIPTION
This has caused a few spurious alerts so far in the lazy relaying path due to trying to read a zero ttl.
