### PR TITLE
benchmarks: increase process startup delay to be more forgiving

### DIFF
--- a/benchmarks/index.js
+++ b/benchmarks/index.js
@@ -58,7 +58,7 @@ function BenchmarkRunner(opts) {
     self.benchProcs = [];
     self.benchCounter = 0;
     self.fileStream = null;
-    self.startClientDelay = 500;
+    self.startClientDelay = 1500;
 
     var SERVER_PORT = 7100;
     var TRACE_SERVER_PORT = 7039;
@@ -88,7 +88,7 @@ BenchmarkRunner.prototype.start = function start() {
     self.spawnTargetServer();
 
     if (self.opts.relay || self.opts.trace) {
-        setTimeout(startRelay, 500);
+        setTimeout(startRelay, 1500);
     } else {
         setTimeout(startClient, self.startClientDelay);
     }


### PR DESCRIPTION
I suspect that we sometimes get flaps because 500ms simply is not
enough to start a thing.

Especially with the Hyperbahn worker which can take more then 500ms
before it listens to a port.

I've bumped the default delays to 1500ms to avoid the benchmarks
from flapping on us.

r: @jcorbin @rf @kriskowal