### PR TITLE
[as-http] reduce memory consumption / GC per request / response

### DIFF
--- a/test/as-http.js
+++ b/test/as-http.js
@@ -37,58 +37,6 @@ function isNumber(assert, value) {
 }
 
 var fixture = {
-    'tchannel.http-handler.egress.request-build-latency': {
-        'name': 'tchannel.http-handler.egress.request-build-latency',
-        'type': 'timing',
-        'value': isNumber,
-        'tags': {
-            'app': '',
-            'host': '',
-            'cluster': '',
-            'version': '',
-            'callerName': 'wat',
-            'targetService': 'test_http'
-        }
-    },
-    'tchannel.http-handler.egress.response-build-latency': {
-        'name': 'tchannel.http-handler.egress.response-build-latency',
-        'type': 'timing',
-        'value': isNumber,
-        'tags': {
-            'app': '',
-            'host': '',
-            'cluster': '',
-            'version': '',
-            'callerName': 'wat',
-            'targetService': 'test_http'
-        }
-    },
-    'tchannel.http-handler.ingress.request-build-latency': {
-        'name': 'tchannel.http-handler.ingress.request-build-latency',
-        'type': 'timing',
-        'value': isNumber,
-        'tags': {
-            'app': '',
-            'host': '',
-            'cluster': '',
-            'version': '',
-            'callerName': 'wat',
-            'targetService': 'test_http'
-        }
-    },
-    'tchannel.http-handler.ingress.response-build-latency': {
-        'name': 'tchannel.http-handler.ingress.response-build-latency',
-        'type': 'timing',
-        'value': isNumber,
-        'tags': {
-            'app': '',
-            'host': '',
-            'cluster': '',
-            'version': '',
-            'callerName': 'wat',
-            'targetService': 'test_http'
-        }
-    },
     'tchannel.http-handler.ingress.service-call-latency': {
         'name': 'tchannel.http-handler.ingress.service-call-latency',
         'type': 'timing',
@@ -101,7 +49,7 @@ var fixture = {
             'callerName': 'wat',
             'targetService': 'test_http'
         }
-    },
+    }
 };
 
 allocHTTPTest('as/http can bridge a service using node http (streaming)', {


### PR DESCRIPTION
Re-use global/static objects (e.g arg2, stat tags, req/res) instead of keep allocating/de-allocating objects.

r: @jcorbin @Raynos @ShanniLi 
cc: @davewhat @vipulaneja 