### PR TITLE
Actually retry on conn identification errors

### DIFF
--- a/request.js
+++ b/request.js
@@ -292,7 +292,18 @@ TChannelRequest.prototype.resend = function resend() {
 
     function onIdentified(err) {
         if (err) {
-            return self.emitError(err);
+            /* emulate outReq failure */
+
+            self.outReqs.push({
+                err: err
+            });
+            if (!self.triedRemoteAddrs) {
+                self.triedRemoteAddrs = {};
+            }
+            self.triedRemoteAddrs[peer.hostPort] =
+                (self.triedRemoteAddrs[peer.hostPort] || 0) + 1;
+
+            return self.onSubreqError(err);
         }
 
         self.onIdentified(peer);


### PR DESCRIPTION
We had a nice "feature" where we retried over connection
errors EXCEPT errors opening a new connection. 

This causes about 1/45 requests to fail in one of 
our production services because 1/45 hyperbahn hosts are
down.

r: @kriskowal @jcorbin @rf

cc: @blampe @prashantv Consider auditing python/go :)

cc: @MadanThangavelu This is the retry bugfix.