### PR TITLE
Add an upper bound to the lifetime of a tombstone

### DIFF
--- a/channel.js
+++ b/channel.js
@@ -1003,4 +1003,16 @@ function sanitySweep(callback) {
     self.peers.sanitySweep(callback);
 };
 
+TChannel.prototype.setMaxTombstoneTTL =
+function setMaxTombstoneTTL(ttl) {
+    var self = this;
+
+    var peers = self.peers.values();
+    for (var i = 0; i < peers.length; i++) {
+        var peer = peers[i];
+
+        peer.setMaxTombstoneTTL(ttl);
+    }
+};
+
 module.exports = TChannel;

--- a/operations.js
+++ b/operations.js
@@ -25,6 +25,7 @@ var inherits = require('util').inherits;
 var EventEmitter = require('./lib/event_emitter');
 
 var TOMBSTONE_TTL_OFFSET = 500;
+var MAX_TOMBSTONE_TTL = 5000;
 
 module.exports = Operations;
 
@@ -90,13 +91,18 @@ function extendLogInfo(info) {
 function OperationTombstone(operations, id, time, req, context) {
     var self = this;
 
+    var timeout = Math.min(
+        TOMBSTONE_TTL_OFFSET + req.timeout,
+        MAX_TOMBSTONE_TTL
+    );
+
     self.type = 'tchannel.operation.tombstone';
     self.isTombstone = true;
     self.logger = operations.logger;
     self.operations = operations;
     self.id = id;
     self.time = time;
-    self.timeout = TOMBSTONE_TTL_OFFSET + req.timeout;
+    self.timeout = timeout;
     self.timeHeapHandle = null;
     self.destroyed = false;
     self.serviceName = req.serviceName;

--- a/operations.js
+++ b/operations.js
@@ -89,6 +89,13 @@ function extendLogInfo(info) {
     return info;
 };
 
+Operations.prototype.setMaxTombstoneTTL =
+function setMaxTombstoneTTL(ttl) {
+    var self = this;
+
+    self.maxTombstoneTTL = ttl;
+};
+
 function OperationTombstone(operations, id, time, req, context) {
     var self = this;
 

--- a/operations.js
+++ b/operations.js
@@ -42,6 +42,7 @@ function Operations(opts) {
     self.logger = opts.logger;
     self.random = opts.random;
     self.connectionStalePeriod = opts.connectionStalePeriod;
+    self.maxTombstoneTTL = MAX_TOMBSTONE_TTL;
 
     self.connection = opts.connection;
     // TODO need this?
@@ -93,7 +94,7 @@ function OperationTombstone(operations, id, time, req, context) {
 
     var timeout = Math.min(
         TOMBSTONE_TTL_OFFSET + req.timeout,
-        MAX_TOMBSTONE_TTL
+        operations.maxTombstoneTTL
     );
 
     self.type = 'tchannel.operation.tombstone';

--- a/peer.js
+++ b/peer.js
@@ -226,6 +226,16 @@ function clearDrain() {
     }
 };
 
+TChannelPeer.prototype.setMaxTombstoneTTL =
+function setMaxTombstoneTTL(ttl) {
+    var self = this;
+
+    for (var i = 0; i < self.connections.length; i++) {
+        var conn = self.connections[i];
+        conn.operations.setMaxTombstoneTTL(ttl);
+    }
+};
+
 TChannelPeer.prototype.setPreferConnectionDirection = function setPreferConnectionDirection(direction) {
     var self = this;
     if (self.preferConnectionDirection === direction) {


### PR DESCRIPTION
This should upper bound the number of tombstones in a process

I think long term we really should have the Operations data
structure be a LRU or some kind of fixed size upper bounded
data structure.

This should reduce GC pressure in hyperbahn

r: @jcorbin @kriskowal @rf