### PR TITLE
Downgrade an invalid ttl error to a warning

### DIFF
--- a/connection.js
+++ b/connection.js
@@ -330,6 +330,12 @@ TChannelConnection.prototype.onErrorFrame = function onErrorFrame(errFrame) {
 
 TChannelConnection.prototype.onHandlerError = function onHandlerError(err) {
     var self = this;
+
+    if (err.isParseError) {
+        self.sendProtocolError('read', err);
+        return;
+    }
+
     self.resetAll(err);
 };
 

--- a/errors.js
+++ b/errors.js
@@ -865,7 +865,7 @@ Errors.logLevel = function errorLogLevel(err, codeName) {
     switch (codeName) {
         case 'ProtocolError':
         case 'UnexpectedError':
-            if (err.isErrorFrame) {
+            if (err.isErrorFrame || Errors.isParseError(err)) {
                 return 'warn';
             }
             return 'error';
@@ -909,4 +909,8 @@ Errors.isPendingError = function isPendingError(codeName) {
         default:
             return false;
     }
+};
+
+Errors.isParseError = function isParseError(error) {
+    return error.isParseError || false;
 };

--- a/relay_handler.js
+++ b/relay_handler.js
@@ -374,10 +374,12 @@ function onReadError(err) {
 
     var hasError = !self.alive && self.error;
     if (hasError) {
-        var info = self.extendLogInfo({
-            error: err
-        });
-        self.logger.warn('dropping read error from dead relay request', info);
+        self.logger.warn(
+            'dropping read error from dead relay request',
+            self.extendLogInfo({
+                error: err
+            })
+        );
     }
 
     self.onError(err);

--- a/relay_handler.js
+++ b/relay_handler.js
@@ -51,7 +51,7 @@ RelayHandler.prototype.handleLazily = function handleLazily(conn, reqFrame) {
     var rereq = new LazyRelayInReq(conn, reqFrame);
     var err = rereq.initRead();
     if (err) {
-        rereq.onError(err);
+        rereq.onReadError(err);
         return true;
     }
 
@@ -366,6 +366,22 @@ function updateTTL(now) {
     }
 
     return timeout;
+};
+
+LazyRelayInReq.prototype.onReadError =
+function onReadError(err) {
+    var self = this;
+
+    var hasError = !self.alive && self.error;
+    if (hasError) {
+        var info = self.extendLogInfo({
+            error: err
+        });
+        self.logger.warn('dropping read error from dead relay request', info);
+    }
+
+    self.onError(err);
+    self.conn.resetAll(err);
 };
 
 LazyRelayInReq.prototype.onError =

--- a/test/non-zero-ttl.js
+++ b/test/non-zero-ttl.js
@@ -20,13 +20,17 @@
 
 'use strict';
 
+var Buffer = require('buffer').Buffer;
 var process = require('process');
+var setTimeout = require('timers').setTimeout;
 
 var allocCluster = require('./lib/alloc-cluster.js');
+var RelayHandler = require('../relay_handler');
 
-allocCluster.test('request() with zero timeout', {
+allocCluster.test('request() with zero timeout (client)', {
     numPeers: 2
 }, function t(cluster, assert) {
+    var client = cluster.channels[0];
     cluster.logger.whitelist('info', 'resetting connection');
 
     warmUpConnection(cluster, onIdentified);
@@ -58,11 +62,14 @@ allocCluster.test('request() with zero timeout', {
         assert.equal(logLine && logLine.meta.error.type,
             'tchannel.protocol.write-failed');
 
+        assert.equal(logLine && logLine.meta.hostPort, client.hostPort,
+            'error occurred on the client');
+
         assert.end();
     }
 });
 
-allocCluster.test('request() with negative timeout', {
+allocCluster.test('request() with negative timeout (client)', {
     numPeers: 2
 }, function t(cluster, assert) {
     cluster.logger.whitelist('info', 'resetting connection');
@@ -95,6 +102,216 @@ allocCluster.test('request() with negative timeout', {
         assert.equal(logLine && logLine.levelName, 'info');
         assert.equal(logLine && logLine.meta.error.type,
             'tchannel.protocol.write-failed');
+
+        assert.end();
+    }
+});
+
+allocCluster.test('request() with zero timeout (server)', {
+    numPeers: 2
+}, function t(cluster, assert) {
+    var client = cluster.channels[0];
+    var server = cluster.channels[1];
+
+    cluster.logger.whitelist('info', 'resetting connection');
+    cluster.logger.whitelist('warn', 'got errorframe without call request');
+
+    warmUpConnection(cluster, onIdentified);
+
+    function onIdentified(err, conn) {
+        assert.ifError(err);
+
+        sendCallRequestFrame(conn, 0);
+        setTimeout(checkLog, 50);
+    }
+
+    function checkLog() {
+        assert.equal(cluster.logger.items().length, 2);
+
+        var serverLine = cluster.logger.items()[0];
+        assert.equal(serverLine && serverLine.levelName, 'info');
+        assert.equal(serverLine && serverLine.msg, 'resetting connection');
+        assert.equal(serverLine && serverLine.meta.error.type,
+            'tchannel.protocol.read-failed');
+        assert.ok(serverLine && serverLine.meta.error.message.indexOf(
+            'Expected positive ttl but got 0') > -1,
+            'expected log line to complain about non-positive ttl'
+        );
+        assert.equal(serverLine && serverLine.meta.hostPort, server.hostPort,
+            'error occurred on the server');
+        assert.equal(serverLine && serverLine.meta.remoteName, client.hostPort,
+            'invalid frame came from the client');
+
+        var clientLine = cluster.logger.items()[1];
+
+        assert.equal(clientLine && clientLine.levelName, 'warn');
+        assert.equal(clientLine && clientLine.msg,
+            'got errorframe without call request');
+        assert.equal(clientLine && clientLine.meta.error.type,
+            'tchannel.protocol');
+        assert.ok(clientLine && clientLine.meta.error.message.indexOf(
+            'Expected positive ttl but got 0') > -1,
+            'expected log line to complain about non-positive ttl'
+        );
+        assert.equal(clientLine && clientLine.meta.hostPort, client.hostPort,
+            'error occurred on the server');
+        assert.equal(clientLine && clientLine.meta.remoteName, server.hostPort,
+            'invalid frame came from the client');
+
+        var cpeers = client.peers.values();
+        var speers = server.peers.values();
+
+        assert.equal(cpeers.length, 1, 'client has one peer');
+        assert.equal(speers.length, 1, 'server has one peer');
+
+        var cconns = cpeers[0].connections;
+        var sconns = speers[0].connections;
+
+        assert.equal(cconns.length, 0, 'client has zero connections');
+        assert.equal(sconns.length, 0, 'server has zero connections');
+
+        assert.end();
+    }
+});
+
+allocCluster.test('request() with zero ttl through relay (server)', {
+    numPeers: 3
+}, function t(cluster, assert) {
+    cluster.logger.whitelist('info', 'resetting connection');
+    cluster.logger.whitelist('warn', 'got errorframe without call request');
+
+    var client = cluster.channels[0];
+    var relay = cluster.channels[1];
+    var server = cluster.channels[2];
+
+    var relayToServer = relay.makeSubChannel({
+        serviceName: 'server',
+        peers: [server.hostPort]
+    });
+    relayToServer.handler = new RelayHandler(relayToServer);
+
+    warmUpConnection(cluster, onIdentified);
+
+    function onIdentified(err, conn) {
+        assert.ifError(err);
+
+        sendCallRequestFrame(conn, 0);
+        setTimeout(checkLog, 50);
+    }
+
+    function checkLog() {
+        assert.equal(cluster.logger.items().length, 2);
+
+        var relayLine = cluster.logger.items()[0];
+        assert.equal(relayLine && relayLine.levelName, 'info');
+        assert.equal(relayLine && relayLine.msg, 'resetting connection');
+        assert.equal(relayLine && relayLine.meta.error.type,
+            'tchannel.protocol.read-failed');
+        assert.ok(relayLine && relayLine.meta.error.message.indexOf(
+            'Expected positive ttl but got 0') > -1,
+            'expected log line to complain about non-positive ttl'
+        );
+        assert.equal(relayLine && relayLine.meta.hostPort, relay.hostPort,
+            'error occurred on the relay');
+        assert.equal(relayLine && relayLine.meta.remoteName, client.hostPort,
+            'invalid frame came from the client');
+
+        var clientLine = cluster.logger.items()[1];
+
+        assert.equal(clientLine && clientLine.levelName, 'warn');
+        assert.equal(clientLine && clientLine.msg,
+            'got errorframe without call request');
+        assert.equal(clientLine && clientLine.meta.error.type,
+            'tchannel.protocol');
+        assert.ok(clientLine && clientLine.meta.error.message.indexOf(
+            'Expected positive ttl but got 0') > -1,
+            'expected log line to complain about non-positive ttl'
+        );
+        assert.equal(clientLine && clientLine.meta.hostPort, client.hostPort,
+            'error occurred on the server');
+        assert.equal(clientLine && clientLine.meta.remoteName, relay.hostPort,
+            'invalid frame came from the client');
+
+        assert.end();
+    }
+});
+
+allocCluster.test('request() with zero ttl through lazy relay (server)', {
+    numPeers: 3
+}, function t(cluster, assert) {
+    cluster.logger.whitelist('info', 'resetting connection');
+    cluster.logger.whitelist('warn', 'error while forwarding');
+    cluster.logger.whitelist('warn', 'got errorframe without call request');
+
+    var client = cluster.channels[0];
+    var relay = cluster.channels[1];
+    var server = cluster.channels[2];
+
+    relay.setLazyHandling(true);
+    relay.setLazyRelaying(true);
+
+    var relayToServer = relay.makeSubChannel({
+        serviceName: 'server',
+        peers: [server.hostPort]
+    });
+    relayToServer.handler = new RelayHandler(relayToServer);
+
+    warmUpConnection(cluster, onIdentified);
+
+    function onIdentified(err, conn) {
+        assert.ifError(err);
+
+        sendCallRequestFrame(conn, 0);
+        setTimeout(checkLog, 50);
+    }
+
+    function checkLog() {
+        assert.equal(cluster.logger.items().length, 3);
+
+        var relayLine = cluster.logger.items()[0];
+        assert.equal(relayLine && relayLine.levelName, 'warn');
+        assert.equal(relayLine && relayLine.msg, 'error while forwarding');
+        assert.equal(relayLine && relayLine.meta.error.type,
+            'tchannel.protocol.invalid-ttl');
+        assert.ok(relayLine && relayLine.meta.error.message.indexOf(
+            'Expected positive ttl but got 0') > -1,
+            'expected log line to complain about non-positive ttl'
+        );
+
+        assert.equal(relayLine && relayLine.meta.hostPort, relay.hostPort,
+            'error occurred on the relay');
+        assert.equal(relayLine && relayLine.meta.remoteName, client.hostPort,
+            'invalid frame came from the client');
+
+        var clientLine = cluster.logger.items()[2];
+
+        assert.equal(clientLine && clientLine.levelName, 'warn');
+        assert.equal(clientLine && clientLine.msg,
+            'got errorframe without call request');
+        assert.equal(clientLine && clientLine.meta.error.type,
+            'tchannel.protocol');
+        assert.ok(clientLine && clientLine.meta.error.message.indexOf(
+            'Expected positive ttl but got 0') > -1,
+            'expected log line to complain about non-positive ttl'
+        );
+        assert.equal(clientLine && clientLine.meta.hostPort, client.hostPort,
+            'error occurred on the server');
+        assert.equal(clientLine && clientLine.meta.remoteName, relay.hostPort,
+            'invalid frame came from the client');
+
+        var connLine = cluster.logger.items()[1];
+        assert.equal(connLine && connLine.levelName, 'info');
+        assert.equal(connLine && connLine.msg, 'resetting connection');
+        assert.equal(connLine && connLine.meta.error.type,
+            'tchannel.protocol.invalid-ttl');
+        assert.ok(connLine && connLine.meta.error.message.indexOf(
+            'Expected positive ttl but got 0') > -1,
+            'expected log line to complain about non-positive ttl'
+        );
+        assert.equal(connLine && connLine.meta.hostPort, relay.hostPort,
+            'error occurred on the relay');
+        assert.equal(connLine && connLine.meta.remoteName, client.hostPort,
+            'invalid frame came from the client');
 
         assert.end();
     }
@@ -145,4 +362,42 @@ function buildRequest(conn, ttl) {
     conn.ops.addOutReq(req);
 
     return req;
+}
+
+function sendCallRequestFrame(conn, ttl, onWrite) {
+    /* eslint no-inline-comments: 0*/
+
+    var callFrameBytes = [
+        0x00, 0x00, // length:2
+        0x03, // type:1
+        0x00, // reserved
+        0x00, 0x00, 0x00, 0x03, // id:4
+        0x00, 0x00, 0x00, 0x00, // reserved:8
+        0x00, 0x00, 0x00, 0x00, // ...
+
+        0x00,                   // flags:1
+        ttl >>> 24, ttl >>> 16, ttl >>> 8, ttl, // ttl:4
+        0x00, 0x01, 0x02, 0x03, // tracing:24
+        0x04, 0x05, 0x06, 0x07, // ...
+        0x08, 0x09, 0x0a, 0x0b, // ...
+        0x0c, 0x0d, 0x0e, 0x0f, // ...
+        0x10, 0x11, 0x12, 0x13, // ...
+        0x14, 0x15, 0x16, 0x17, // ...
+        0x18,                   // traceflags:1
+        0x06,                   // service~1
+        0x73, 0x65, 0x72, 0x76, // ...
+        0x65, 0x72,             // ...
+        0x00,                   // nh:1
+        0x02,  // csumtype:1
+        0x8e, 0x09, 0xa1, 0xbd, // (csum:4){0,1}
+        0x00, 0x02, 0x6f, 0x6e, // arg1~2
+        0x00, 0x02, 0x74, 0x6f, // arg2~2
+        0x00, 0x02, 0x74, 0x65  // arg3~2
+    ];
+
+    // Assign length of frame
+    callFrameBytes[1] = callFrameBytes.length;
+
+    var buffer = new Buffer(callFrameBytes);
+    conn.socket.write(buffer, onWrite);
 }

--- a/test/non-zero-ttl.js
+++ b/test/non-zero-ttl.js
@@ -176,7 +176,7 @@ allocCluster.test('request() with zero timeout (server)', {
     }
 });
 
-allocCluster.test('request() with zero ttl through relay (server)', {
+allocCluster.test('request() with zero ttl through eager relay (server)', {
     numPeers: 3
 }, function t(cluster, assert) {
     cluster.logger.whitelist('info', 'resetting connection');
@@ -185,6 +185,9 @@ allocCluster.test('request() with zero ttl through relay (server)', {
     var client = cluster.channels[0];
     var relay = cluster.channels[1];
     var server = cluster.channels[2];
+
+    relay.setLazyHandling(false);
+    relay.setLazyRelaying(false);
 
     var relayToServer = relay.makeSubChannel({
         serviceName: 'server',

--- a/test/non-zero-ttl.js
+++ b/test/non-zero-ttl.js
@@ -342,7 +342,6 @@ function warmUpConnection(cluster, cb) {
 function buildRequest(conn, ttl) {
     var peer = conn.channel.peers.get(conn.socketRemoteAddr);
 
-    // fff magic test
     var req = conn.buildOutRequest({
         channel: conn.channel,
         peer: peer,
@@ -355,8 +354,8 @@ function buildRequest(conn, ttl) {
         checksumType: null,
         timers: conn.channel.timers,
         headers: {
-            'as': 'raw',
-            'cn': 'wat'
+            as: 'raw',
+            cn: 'wat'
         }
     });
     conn.ops.addOutReq(req);
@@ -368,15 +367,18 @@ function sendCallRequestFrame(conn, ttl, onWrite) {
     /* eslint no-inline-comments: 0*/
 
     var callFrameBytes = [
-        0x00, 0x00, // length:2
-        0x03, // type:1
-        0x00, // reserved
+        0x00, 0x00,             // length:2
+        0x03,                   // type:1
+        0x00,                   // reserved
         0x00, 0x00, 0x00, 0x03, // id:4
         0x00, 0x00, 0x00, 0x00, // reserved:8
         0x00, 0x00, 0x00, 0x00, // ...
 
         0x00,                   // flags:1
-        ttl >>> 24, ttl >>> 16, ttl >>> 8, ttl, // ttl:4
+        ttl >>> 24 & 0xff,      // ttl:4
+        ttl >>> 16 & 0xff,      // ...
+        ttl >>> 8 & 0xff,       // ...
+        ttl & 0xff,             // ...
         0x00, 0x01, 0x02, 0x03, // tracing:24
         0x04, 0x05, 0x06, 0x07, // ...
         0x08, 0x09, 0x0a, 0x0b, // ...

--- a/test/non-zero-ttl.js
+++ b/test/non-zero-ttl.js
@@ -144,9 +144,11 @@ allocCluster.test('request() with zero timeout (server)', {
 
         var clientLine = cluster.logger.items()[1];
 
-        assert.equal(clientLine && clientLine.levelName, 'warn');
+        assert.equal(clientLine && clientLine.levelName, 'warn',
+            'clientLine should be warning');
         assert.equal(clientLine && clientLine.msg,
-            'got errorframe without call request');
+            'got errorframe without call request',
+            'clientLine message should be errorframe without call req');
         assert.equal(clientLine && clientLine.meta.error.type,
             'tchannel.protocol');
         assert.ok(clientLine && clientLine.meta.error.message.indexOf(

--- a/v2/call.js
+++ b/v2/call.js
@@ -76,7 +76,8 @@ CallRequest.RW.lazy.readTTL = function readTTL(frame) {
     var res = bufrw.UInt32BE.readFrom(frame.buffer, CallRequest.RW.lazy.ttlOffset);
     if (!res.err && res.value <= 0) {
         res.err = errors.InvalidTTL({
-            ttl: res.value
+            ttl: res.value,
+            isParseError: true
         });
     }
     return res;
@@ -209,7 +210,8 @@ function readCallReqFrom(buffer, offset) {
 
     if (res.value <= 0) {
         return bufrw.ReadResult.error(errors.InvalidTTL({
-            ttl: res.value
+            ttl: res.value,
+            isParseError: true
         }), offset, body);
     }
 

--- a/v2/handler.js
+++ b/v2/handler.js
@@ -172,7 +172,7 @@ TChannelV2Handler.prototype.handleLazyFrame = function handleLazyFrame(frame) {
 
     var res = frame.readBody();
     if (res.err) {
-        self.errorEvent.emit(res.err);
+        self.errorEvent.emit(self, res.err);
         return;
     }
 

--- a/v2/lazy_frame.js
+++ b/v2/lazy_frame.js
@@ -25,6 +25,7 @@ var bufrw = require('bufrw');
 var errors = require('../errors');
 
 var Frame = require('./frame.js');
+var Types = require('./index.js').Types;
 
 module.exports = LazyFrame;
 
@@ -67,7 +68,15 @@ LazyFrame.prototype.readBody = function readBody() {
     }
 
     var res = self.bodyRW.readFrom(self.buffer, LazyFrame.BodyOffset);
-    if (!res.err) {
+
+    if (res.err) {
+        if (self.type === Types.CallRequest ||
+            self.type === Types.CallRequestCont
+        ) {
+            // TODO: wrapped?
+            res.err.frameId = self.id;
+        }
+    } else {
         self.body = res.value;
     }
 


### PR DESCRIPTION
This change improves the relay code so that frame
parsing errors do not create errors.

 - Adds tests for non-negative ttl aimed at servers
 - Add an isParseError pattern to errors
 - Mark InvalidTTL errors as parse errors
 - Add logging to connection about unknown error frames
 - Improve lazy relay by closing conn on protocol error

r: @jcorbin @rf