### PR TITLE
relay_handler: when logging add conneciton context

### DIFF
--- a/relay_handler.js
+++ b/relay_handler.js
@@ -225,6 +225,10 @@ LazyRelayInReq.prototype.extendLogInfo =
 function extendLogInfo(info) {
     var self = this;
 
+    if (self.conn) {
+        info = self.conn.extendLogInfo(info);
+    }
+
     if (self.outreq) {
         info = self.outreq._extendLogInfo(info);
     }
@@ -525,6 +529,10 @@ LazyRelayOutReq.prototype.type = 'tchannel.lazy.outgoing-request';
 LazyRelayOutReq.prototype.extendLogInfo =
 function extendLogInfo(info) {
     var self = this;
+
+    if (self.conn) {
+        info = self.conn.extendLogInfo(info);
+    }
 
     if (self.inreq) {
         info = self.inreq._extendLogInfo(info);


### PR DESCRIPTION
We should add connection context to logging on the relay.
This will greatly aid debugging.

r: @jcorbin @rf