### PR TITLE
increase setTimeout to reduce flaps

### DIFF
--- a/test/relay_lazy.js
+++ b/test/relay_lazy.js
@@ -315,7 +315,7 @@ allocCluster.test('relay request times out', {
                   'expected timeout error');
         assert.notOk(res, 'expected no response');
 
-        setTimeout(finish, 1);
+        setTimeout(finish, 10);
     }
 
     function finish() {

--- a/test/relay_lazy.js
+++ b/test/relay_lazy.js
@@ -315,7 +315,7 @@ allocCluster.test('relay request times out', {
                   'expected timeout error');
         assert.notOk(res, 'expected no response');
 
-        setTimeout(finish, 10);
+        setTimeout(finish, 100);
     }
 
     function finish() {


### PR DESCRIPTION
This fixes a test flap. This test has non-deterministic
client or server timeouts.

By waiting 10ms the server is more likely to time out.

r: @jcorbin @kriskowal