### PR TITLE
Fix time granularity

### DIFF
--- a/channel.js
+++ b/channel.js
@@ -170,17 +170,8 @@ function TChannel(options) {
     // for processing operation timeouts
     self.timeHeap = self.options.timeHeap || new TimeHeap({
         timers: self.timers,
-        // TODO: do we still need/want fuzzing?
-        minTimeout: fuzzedMinTimeout
+        minTimeout: self.options.timeoutCheckInterval
     });
-
-    function fuzzedMinTimeout() {
-        var fuzz = self.options.timeoutFuzz;
-        if (fuzz) {
-            fuzz = Math.floor(fuzz * (self.random() - 0.5));
-        }
-        return self.options.timeoutCheckInterval + fuzz;
-    }
 
     // how to handle incoming requests
     if (!self.options.handler) {

--- a/channel.js
+++ b/channel.js
@@ -118,7 +118,7 @@ function TChannel(options) {
     self.options = extend({
         useLazyHandling: false,
         useLazyRelaying: true,
-        timeoutCheckInterval: 100,
+        timeoutCheckInterval: 10,
         timeoutFuzz: 100,
         connectionStalePeriod: CONN_STALE_PERIOD,
 


### PR DESCRIPTION
Finally bringing this up: the time heap and its "set exactly one timer, the next one" obsoleted the need for fuzzing, let alone large interval.  For historical reasons we kept these, meaning to remove them eventually.

I'd argue that we don't even want a minimum of any sorts on the next timer, but for now I'm only proposing that we drop it to 10ms.