### PR TITLE
request-handler: emit error when failed to parse arg2/arg3

### DIFF
--- a/request-handler.js
+++ b/request-handler.js
@@ -54,8 +54,12 @@ RequestCallbackHandler.prototype.handleRequest = function handleRequest(req, bui
     var res;
     if (req.streamed) {
         req.withArg23(function onArg23(err, arg2, arg3) {
+            if (err) {
+                return req.emitError(err);
+            }
+
             if (req.res && req.res.responseAlreadyDone()) {
-                return;
+                return null;
             }
 
             res = buildResponse({streamed: false});

--- a/request-handler.js
+++ b/request-handler.js
@@ -56,7 +56,7 @@ RequestCallbackHandler.prototype.handleRequest = function handleRequest(req, bui
         req.withArg23(function onArg23(err, arg2, arg3) {
             if (err) {
                 req.channel.logger.warn(
-                    'Could not parse arg3 for streaming inreq',
+                    'Could not parse arg2/arg3 for streaming inreq',
                     req.extendLogInfo({
                         error: err
                     })

--- a/request-handler.js
+++ b/request-handler.js
@@ -55,6 +55,13 @@ RequestCallbackHandler.prototype.handleRequest = function handleRequest(req, bui
     if (req.streamed) {
         req.withArg23(function onArg23(err, arg2, arg3) {
             if (err) {
+                req.channel.logger.warn(
+                    'Could not parse arg3 for streaming inreq',
+                    req.extendLogInfo({
+                        error: err
+                    })
+                );
+
                 return req.emitError(err);
             }
 

--- a/request-handler.js
+++ b/request-handler.js
@@ -62,11 +62,12 @@ RequestCallbackHandler.prototype.handleRequest = function handleRequest(req, bui
                     })
                 );
 
-                return req.emitError(err);
+                req.emitError(err);
+                return;
             }
 
             if (req.res && req.res.responseAlreadyDone()) {
-                return null;
+                return;
             }
 
             res = buildResponse({streamed: false});


### PR DESCRIPTION
We completely swallowed errors when failing to parse args.

This is BAD (tm).

r: @jcorbin @rf @kriskowal