### PR TITLE
Ensure we always pass a callback to sanitySweep.

### DIFF
--- a/channel.js
+++ b/channel.js
@@ -38,6 +38,7 @@ var extend = require('xtend');
 var globalTimers = extend(require('timers'), {
     now: Date.now
 });
+var setImmediate = require('timers').setImmediate;
 var globalRandom = Math.random;
 var net = require('net');
 var format = require('util').format;
@@ -934,12 +935,31 @@ function sanitySweep(callback) {
     }
 
     var incomingConns = Object.keys(self.serverConnections);
-    for (var i = 0; i < incomingConns.length; i++) {
-        var conn = self.serverConnections[incomingConns[i]];
-        conn.ops.sanitySweep();
-    }
 
-    self.peers.sanitySweep(callback);
+    nextConn(incomingConns, 0, function connSweepDone(err) {
+        if (err) {
+            callback(err);
+            return;
+        }
+
+        self.peers.sanitySweep(callback);
+    });
+
+    function nextConn(connectionKeys, index, cb) {
+        if (index >= connectionKeys.length) {
+            cb(null);
+            return;
+        }
+
+        var connection = self.serverConnections[connectionKeys[index]];
+        connection.ops.sanitySweep(function opsSweepDone() {
+            setImmediate(deferNextConn);
+        });
+
+        function deferNextConn() {
+            nextConn(connectionKeys, index + 1, cb);
+        }
+    }
 };
 
 TChannel.prototype.setMaxTombstoneTTL =

--- a/channel.js
+++ b/channel.js
@@ -928,12 +928,15 @@ TChannel.prototype.sanitySweep =
 function sanitySweep(callback) {
     var self = this;
 
-    if (self.serverConnections) {
-        var incomingConns = Object.keys(self.serverConnections);
-        for (var i = 0; i < incomingConns.length; i++) {
-            var conn = self.serverConnections[incomingConns[i]];
-            conn.ops.sanitySweep();
-        }
+    if (!self.serverConnections) {
+        self.peers.sanitySweep(callback);
+        return;
+    }
+
+    var incomingConns = Object.keys(self.serverConnections);
+    for (var i = 0; i < incomingConns.length; i++) {
+        var conn = self.serverConnections[incomingConns[i]];
+        conn.ops.sanitySweep();
     }
 
     self.peers.sanitySweep(callback);

--- a/root_peers.js
+++ b/root_peers.js
@@ -57,11 +57,14 @@ TChannelRootPeers.prototype.sanitySweep =
 function sanitySweep(callback) {
     var self = this;
 
-    if (self.selfPeer) {
-        for (var i = 0; i < self.selfPeer.connections.length; i++) {
-            var conn = self.selfPeer.connections[i];
-            conn.ops.sanitySweep();
-        }
+    if (!self.selfPeer) {
+        TChannelPeersBase.prototype.sanitySweep.call(self, callback);
+        return;
+    }
+
+    for (var i = 0; i < self.selfPeer.connections.length; i++) {
+        var conn = self.selfPeer.connections[i];
+        conn.ops.sanitySweep();
     }
 
     TChannelPeersBase.prototype.sanitySweep.call(self, callback);


### PR DESCRIPTION
Not passing a callback causes a uncaught exception in production.

r: @jcorbin @kriskowal @rf