### PR TITLE
Improve the semantics of InRequest.onTimeout()

### DIFF
--- a/in_request.js
+++ b/in_request.js
@@ -182,7 +182,9 @@ TChannelInRequest.prototype.onTimeout = function onTimeout(now) {
     }
 
     function deferInReqTimeoutErrorEmit() {
-        self.emitError(timeoutError);
+        if (!self.res || self.res.state === States.Initial) {
+            self.emitError(timeoutError);
+        }
     }
 };
 

--- a/in_request.js
+++ b/in_request.js
@@ -169,9 +169,6 @@ TChannelInRequest.prototype.onTimeout = function onTimeout(now) {
         // TODO: send an error frame response?
         // TODO: emit error on self.res instead / in addition to?
         // TODO: should cancel any pending handler
-        if (self.operations) {
-            self.operations.popInReq(self.id);
-        }
         timeoutError = errors.RequestTimeoutError({
             id: self.id,
             start: self.start,
@@ -182,8 +179,13 @@ TChannelInRequest.prototype.onTimeout = function onTimeout(now) {
     }
 
     function deferInReqTimeoutErrorEmit() {
+
         if (!self.res || self.res.state === States.Initial) {
             self.emitError(timeoutError);
+        }
+
+        if (self.operations) {
+            self.operations.popInReq(self.id);
         }
     }
 };

--- a/in_request.js
+++ b/in_request.js
@@ -179,7 +179,6 @@ TChannelInRequest.prototype.onTimeout = function onTimeout(now) {
     }
 
     function deferInReqTimeoutErrorEmit() {
-
         if (!self.res || self.res.state === States.Initial) {
             self.emitError(timeoutError);
         }


### PR DESCRIPTION
There is a lot of nuanced code here that I found whilst
trying to verify the semantics of timeouts against
the relay handler.

These commits make the code stabler and get rid of
some confusing logs, namely send response after timeout
and orphaned conn onReqDone

r: @jcorbin @rf @kriskowal