### PR TITLE
Clamp the maximum ttl in the relay.

### DIFF
--- a/relay_handler.js
+++ b/relay_handler.js
@@ -25,6 +25,7 @@ var stat = require('./stat-tags.js');
 
 var LazyRelayInReq = require('./lazy_relay.js').LazyRelayInReq;
 var logError = require('./lazy_relay.js').logError;
+var MAXIMUM_TTL_ALLOWED = require('./lazy_relay.js').MAXIMUM_TTL_ALLOWED;
 
 RelayHandler.RelayRequest = RelayRequest;
 
@@ -177,6 +178,19 @@ RelayRequest.prototype.onIdentified = function onIdentified() {
 
     var elapsed = self.channel.timers.now() - self.inreq.start;
     var timeout = Math.max(self.inreq.timeout - elapsed, 1);
+
+    if (timeout > MAXIMUM_TTL_ALLOWED) {
+        self.logger.warn(
+            'Clamping timeout to maximum ttl allowed',
+            self.extendLogInfo({
+                timeout: timeout,
+                maximumTTL: MAXIMUM_TTL_ALLOWED
+            })
+        );
+
+        timeout = MAXIMUM_TTL_ALLOWED;
+    }
+
     // TODO use a type for this literal
     self.outreq = self.channel.request({
         peer: self.peer,

--- a/test/index.js
+++ b/test/index.js
@@ -73,6 +73,7 @@ require('./lazy_handler.js');
 require('./lazy_conn_handler.js');
 require('./chan_drain.js');
 require('./peer_drain.js');
+require('./relay-clamps-the-ttl.js');
 
 require('./trace/basic_server.js');
 require('./trace/server_2_requests.js');

--- a/test/relay-clamps-the-ttl.js
+++ b/test/relay-clamps-the-ttl.js
@@ -1,0 +1,86 @@
+// Copyright (c) 2015 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+'use strict';
+
+var allocCluster = require('./lib/alloc-cluster');
+var RelayHandler = require('../relay_handler');
+
+allocCluster.test('relay will clamp ttl to 2 minutes', {
+    numPeers: 3
+}, function t(cluster, assert) {
+    cluster.logger.whitelist('warn', 'Clamping timeout to maximum ttl allowed');
+
+    var client = cluster.channels[0];
+    var relay = cluster.channels[1];
+    var server = cluster.channels[2];
+
+    var subClient = client.makeSubChannel({
+        serviceName: 'server',
+        peers: [relay.hostPort],
+        requestDefaults: {
+            hasNoParent: true,
+            headers: {
+                as: 'raw',
+                cn: 'client'
+            }
+        }
+    });
+    var subServer = server.makeSubChannel({
+        serviceName: 'server'
+    });
+    var subRelay = relay.makeSubChannel({
+        serviceName: 'server',
+        peers: [server.hostPort]
+    });
+    subRelay.handler = new RelayHandler(subRelay);
+
+    subServer.register('echo', echo);
+
+    subClient.request({
+        serviceName: 'server',
+        timeout: 5 * 60 * 1000
+    }).send('echo', 'a', 'b', onResponse);
+
+    function echo(req, res, arg2, arg3) {
+        assert.equal(req.timeout, 2 * 60 * 1000);
+
+        res.headers.as = 'raw';
+        res.sendOk(arg2, arg3);
+    }
+
+    function onResponse(err, resp) {
+        assert.ifError(err);
+
+        assert.equal(resp.ok, true);
+
+        var items = cluster.logger.items();
+        assert.equal(items.length, 1);
+
+        var logLine = items[0];
+        assert.equal(logLine.levelName, 'warn');
+        assert.equal(logLine.msg, 'Clamping timeout to maximum ttl allowed');
+
+        assert.equal(logLine.meta.maximumTTL, 2 * 60 * 1000);
+        assert.ok(logLine.meta.timeout > 2 * 60 * 1000);
+
+        assert.end();
+    }
+});


### PR DESCRIPTION
We've had production problems where people accidentaly
set the time timeout to 1 million milliseconds (i.e. 16
minutes).

This change clamps the ttl to some sensible maximum for
safety reasons.

r: @jcorbin @rf