### PR TITLE
Add goals to peer draining

### DIFF
--- a/drain.js
+++ b/drain.js
@@ -53,8 +53,8 @@ PeerDrain.prototype.extendLogInfo =
 function extendLogInfo(info) {
     var self = this;
 
-    info.drainTimeout = self.timeout;
     info.drainReason = self.reason;
+    info.drainTimeout = self.timeout;
     info.drainDirection = self.direction;
     info.drainStartedAt = self.startedAt;
     info.drainStoppedAt = self.stoppedAt;

--- a/drain.js
+++ b/drain.js
@@ -115,13 +115,8 @@ function start() {
                 self.timer = null;
             }
         }
-        if (!self.finishedAt) {
-            self.finishedAt = now;
-            if (self.callback) {
-                self.callback(err);
-                self.callback = null;
-            }
-        }
+
+        self.finish(err, now);
     }
 };
 
@@ -140,6 +135,20 @@ function stop() {
     }
 
     self.callback = null;
+};
+
+PeerDrain.prototype.finish =
+function finish(err, now) {
+    var self = this;
+
+    if (!self.finishedAt) {
+        self.finishedAt = now;
+
+        if (self.callback) {
+            self.callback(err);
+            self.callback = null;
+        }
+    }
 };
 
 PeerDrain.prototype.drainConnection =

--- a/peer.js
+++ b/peer.js
@@ -120,6 +120,10 @@ function TChannelPeer(channel, hostPort, options) {
 
 inherits(TChannelPeer, EventEmitter);
 
+TChannelPeer.prototype.DRAIN_GOAL_NOOP = PeerDrain.GOAL_NOOP;
+TChannelPeer.prototype.DRAIN_GOAL_CLOSE_DRAINED = PeerDrain.GOAL_CLOSE_DRAINED;
+TChannelPeer.prototype.DRAIN_GOAL_CLOSE_PEER = PeerDrain.GOAL_CLOSE_PEER;
+
 TChannelPeer.prototype.toString =
 function toString() {
     var self = this;


### PR DESCRIPTION
Easy to accomodate now that we have the explicit `PeerDrain` object.  As
mentioned in early review for peer drain, we always wanted to have the ability
to say "and then ...".

This adds the two "and then ..."s that are used in Hyperbahn now/soon.

r @raynos @rf