### PR TITLE
Fix streaming bug in as/http

### DIFF
--- a/as/http.js
+++ b/as/http.js
@@ -394,7 +394,18 @@ TChannelHTTP.prototype.forwardToTChannel = function forwardToTChannel(tchannel, 
                 hres.writeHead(head.statusCode, headers);
             }
             if (bodyStream !== null) {
-                bodyStream.pipe(hres);
+                if (bodyStream._readableState.ended) {
+                    bodyStream.onValueReady(function onValue(err, buffer) {
+                        if (err) {
+                            return self._sendHTTPError(hres, err);
+                        }
+
+                        hres.write(buffer);
+                        hres.end();
+                    });
+                } else {
+                    bodyStream.pipe(hres);
+                }
             } else {
                 hres.end(bodyArg);
             }

--- a/as/http.js
+++ b/as/http.js
@@ -395,9 +395,9 @@ TChannelHTTP.prototype.forwardToTChannel = function forwardToTChannel(tchannel, 
             }
             if (bodyStream !== null) {
                 if (bodyStream._readableState.ended) {
-                    bodyStream.onValueReady(function onValue(err, buffer) {
-                        if (err) {
-                            return self._sendHTTPError(hres, err);
+                    bodyStream.onValueReady(function onValue(err2, buffer) {
+                        if (err2) {
+                            return self._sendHTTPError(hres, err2);
                         }
 
                         hres.write(buffer);

--- a/test/as-http.js
+++ b/test/as-http.js
@@ -287,7 +287,8 @@ allocHTTPTest('as/http can handle a timeout', {
 });
 
 allocHTTPTest('as/http can do large requests', {
-    onServiceRequest: handleHTTPPipe
+    onServiceRequest: handleHTTPPipe,
+    enableLBPool: true
 }, function t(cluster, assert) {
     var chunks = [];
     for (var i = 0; i < 4096; i++) {
@@ -308,10 +309,11 @@ allocHTTPTest('as/http can do large requests', {
 });
 
 allocHTTPTest('as/http can do massive requests', {
-    onServiceRequest: handleHTTPPipe
+    onServiceRequest: handleHTTPPipe,
+    enableLBPool: true
 }, function t(cluster, assert) {
     var chunks = [];
-    for (var i = 0; i < 96096; i++) {
+    for (var i = 0; i < 95000; i++) {
         chunks.push('A');
     }
 
@@ -362,6 +364,11 @@ function makeRequest(cluster, body, cb) {
 function handleHTTPPipe(hreq, hres) {
     hres.statusCode = 200;
     hreq.pipe(hres);
+    hres.once('finish', onFinish);
+
+    function onFinish() {
+        hreq.connection.destroy();
+    }
 }
 
 function handleTestHTTPTimeout(hreq, hres) {

--- a/test/as-http.js
+++ b/test/as-http.js
@@ -26,6 +26,7 @@ var http = require('http');
 var parallel = require('run-parallel');
 var PassThrough = require('stream').PassThrough;
 var test = require('tape');
+var StringDecoder = require('string_decoder').StringDecoder;
 
 var TChannelHTTP = require('../as/http.js');
 var allocCluster = require('./lib/alloc-cluster.js');
@@ -284,6 +285,84 @@ allocHTTPTest('as/http can handle a timeout', {
 
     ], assert.end);
 });
+
+allocHTTPTest('as/http can do large requests', {
+    onServiceRequest: handleHTTPPipe
+}, function t(cluster, assert) {
+    var chunks = [];
+    for (var i = 0; i < 4096; i++) {
+        chunks.push('A');
+    }
+
+    var body = chunks.join('');
+    makeRequest(cluster, body, onResponse);
+
+    function onResponse(err, resp, respBody) {
+        assert.ifError(err);
+
+        assert.equal(resp.statusCode, 200);
+        assert.equal(body, respBody);
+
+        assert.end();
+    }
+});
+
+allocHTTPTest('as/http can do massive requests', {
+    onServiceRequest: handleHTTPPipe
+}, function t(cluster, assert) {
+    var chunks = [];
+    for (var i = 0; i < 96096; i++) {
+        chunks.push('A');
+    }
+
+    var body = chunks.join('');
+    makeRequest(cluster, body, onResponse);
+
+    function onResponse(err, resp, respBody) {
+        assert.ifError(err);
+
+        assert.equal(resp.statusCode, 200);
+        assert.equal(body, respBody);
+
+        assert.end();
+    }
+});
+
+function makeRequest(cluster, body, cb) {
+    var decoder = new StringDecoder('utf8');
+    var chunks = [];
+    var req = http.request({
+        host: cluster.requestOptions.host,
+        port: cluster.requestOptions.port,
+        method: 'POST',
+        path: '/wat'
+    }, onResponse);
+
+    req.on('error', onError);
+    req.end(body);
+
+    function onError(err) {
+        cb(err);
+    }
+
+    function onResponse(resp) {
+        resp.on('data', onData);
+        resp.on('end', onEnd);
+
+        function onData(buffer) {
+            chunks.push(decoder.write(buffer));
+        }
+
+        function onEnd() {
+            cb(null, resp, chunks.join(''));
+        }
+    }
+}
+
+function handleHTTPPipe(hreq, hres) {
+    hres.statusCode = 200;
+    hreq.pipe(hres);
+}
 
 function handleTestHTTPTimeout(hreq, hres) {
     setTimeout(


### PR DESCRIPTION
We found a weird edgecase where we didnt send the response.

This fixes it by checking for the ended edgecase and sending
back the entire data.

r: @jcorbin @rf @Matt-Esch