### PR TITLE
Protect against TCP socket being full.

### DIFF
--- a/connection.js
+++ b/connection.js
@@ -235,17 +235,20 @@ function writeToSocket(buf) {
     if (self.socket._writableState.buffer.length >
         MAX_PENDING_SOCKET_WRITE_REQ
     ) {
+        var error = errors.SocketWriteFullError({
+            pendingWrites: self.socket._writableState.buffer.length
+        });
         self.logger.warn('resetting connection due to write backup',
             self.extendLogInfo({
                 pendingWrites: self.socket._writableState.buffer.length,
-                totalFastBufferBytes: self.socket._writableState.length
+                totalFastBufferBytes: self.socket._writableState.length,
+                lastBufferLength: buf.length,
+                error: error
             })
         );
 
         // NUKE THE SOCKET
-        self.resetAll(errors.SocketWriteFullError({
-            pendingWrites: self.socket._writableState.buffer.length
-        }));
+        self.resetAll(error);
         return;
     }
 

--- a/connection.js
+++ b/connection.js
@@ -237,8 +237,8 @@ function writeToSocket(buf) {
     ) {
         self.logger.warn('resetting connection due to write backup',
             self.extendLogInfo({
-                bufferLength: self.socket._writableState.buffer.length,
-                maxlen: self.socket._writableState.length
+                pendingWrites: self.socket._writableState.buffer.length,
+                totalFastBufferBytes: self.socket._writableState.length
             })
         );
 

--- a/connection.js
+++ b/connection.js
@@ -159,8 +159,8 @@ TChannelConnection.prototype.setupHandler = function setupHandler() {
 
     self.setLazyHandling(self.channel.options.useLazyHandling);
 
-    self.handler.write = function write(buf, done) {
-        self.socket.write(buf, null, done);
+    self.handler.write = function write(buf) {
+        self.socket.write(buf);
     };
 
     self.mach.emit = handleReadFrame;

--- a/connection.js
+++ b/connection.js
@@ -160,7 +160,7 @@ TChannelConnection.prototype.setupHandler = function setupHandler() {
     self.setLazyHandling(self.channel.options.useLazyHandling);
 
     self.handler.write = function write(buf) {
-        self.socket.write(buf);
+        self.writeToSocket(buf);
     };
 
     self.mach.emit = handleReadFrame;
@@ -224,6 +224,13 @@ TChannelConnection.prototype.setupHandler = function setupHandler() {
     function onCallErrorFrame(errFrame) {
         self.onCallErrorFrame(errFrame);
     }
+};
+
+TChannelConnection.prototype.writeToSocket =
+function writeToSocket(buf) {
+    var self = this;
+
+    self.socket.write(buf);
 };
 
 TChannelConnection.prototype.sendProtocolError =

--- a/connection.js
+++ b/connection.js
@@ -243,7 +243,7 @@ function writeToSocket(buf) {
         );
 
         // NUKE THE SOCKET
-        self.resetAll(Error.SocketWriteFullError({
+        self.resetAll(errors.SocketWriteFullError({
             pendingWrites: self.socket._writableState.buffer.length
         }));
         return;

--- a/errors.js
+++ b/errors.js
@@ -486,7 +486,7 @@ Errors.SocketError = WrappedError({
 
 Errors.SocketWriteFullError = TypedError({
     type: 'tchannel.socket.write-full',
-    message: 'Could not write to socket; socket is full',
+    message: 'Could not write to socket; socket has {pendingWrites} writes',
     pendingWrites: null
 });
 

--- a/errors.js
+++ b/errors.js
@@ -484,6 +484,12 @@ Errors.SocketError = WrappedError({
     remoteAddr: null
 });
 
+Errors.SocketWriteFullError = TypedError({
+    type: 'tchannel.socket.write-full',
+    message: 'Could not write to socket; socket is full',
+    pendingWrites: null
+});
+
 Errors.TChannelConnectionCloseError = TypedError({
     type: 'tchannel.connection.close',
     message: 'connection closed'
@@ -726,6 +732,7 @@ Errors.classify = function classify(err) {
         case 'tchannel.socket':
         case 'tchannel.socket-closed':
         case 'tchannel.socket-local-closed':
+        case 'tchannel.socket.write-full':
             return 'NetworkError';
 
         case 'tchannel-json-handler.stringify-error.body-failed':

--- a/errors.js
+++ b/errors.js
@@ -732,7 +732,6 @@ Errors.classify = function classify(err) {
         case 'tchannel.socket':
         case 'tchannel.socket-closed':
         case 'tchannel.socket-local-closed':
-        case 'tchannel.socket.write-full':
             return 'NetworkError';
 
         case 'tchannel-json-handler.stringify-error.body-failed':
@@ -756,6 +755,7 @@ Errors.classify = function classify(err) {
         case 'tchannel.response-already-started':
         case 'tchannel.response-frame-state':
         case 'tchannel.server.listen-failed':
+        case 'tchannel.socket.write-full':
         case 'tchannel.top-level-register':
         case 'tchannel.top-level-request':
         case 'tchannel.tracer.parent-required':

--- a/lazy_relay.js
+++ b/lazy_relay.js
@@ -366,7 +366,7 @@ function handleFrameLazily(frame) {
     }
 
     frame.setId(self.outreq.id);
-    self.outreq.conn.socket.write(frame.buffer);
+    self.outreq.conn.writeToSocket(frame.buffer);
     if (frame.bodyRW.lazy.isFrameTerminal(frame)) {
         self.alive = false;
         self.conn.ops.popInReq(self.id, self.extendLogInfo({
@@ -568,7 +568,7 @@ function handleFrameLazily(frame) {
     var self = this;
 
     frame.setId(self.inreq.id);
-    self.inreq.conn.socket.write(frame.buffer);
+    self.inreq.conn.writeToSocket(frame.buffer);
     if (frame.bodyRW.lazy.isFrameTerminal(frame)) {
         self.conn.ops.popOutReq(self.id, self.extendLogInfo({
             info: 'lazy relay request done',

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "benchmark": "echo '!!! DEPRECATED: Better to just run `node benchmarks` directly' >&2; node benchmarks",
     "hyperbahn-link-test": "./test/link_hyperbahn.sh",
     "tcurl-link-test": "./test/link_tcurl.sh",
-    "check-benchmark": "node benchmarks -- -r 10000 -p 10000",
+    "check-benchmark": "node benchmarks -- -r 10000 -p 1000",
     "take-benchmark": "make -C benchmarks take",
     "take-relay-benchmark": "make -C benchmarks take_relay",
     "take-trace-benchmark": "amke -C benchmarks take_trace",


### PR DESCRIPTION
This gaurd will close the socket if we have too many
pending write operations.

This only happens if there is something wrong with the
socket; i.e. the uv_write call never calls the timeout
which we've seen in prod; something about the socket just
never calls the _write() callback.

I've checked a healthy 30% CPU worker and it only has two
pending WriteReq in memory; note that if libuv & stream_wrap
can flush the buffer synchrously then the cb to _write
gets called synchronously.

This should fix the memory leak we've seen in prod for the
last 24 hours.

r: @jcorbin @rf @kriskowal