### PR TITLE
Use xorshift to generate tracing ids

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "sse4_crc32": "3.2.0",
     "tape-cluster": "2.1.0",
     "thriftrw": "3.0.1",
+    "xorshift": "^0.2.0",
     "xtend": "^4.0.0"
   },
   "devDependencies": {

--- a/trace/span.js
+++ b/trace/span.js
@@ -20,9 +20,7 @@
 
 'use strict';
 
-var LCG = require('../lib/lcg');
-
-var rng = new LCG();
+var xorshift = require('xorshift');
 
 module.exports = Span;
 module.exports.Endpoint = Endpoint;
@@ -89,14 +87,14 @@ Span.prototype.toJSON = function toJSON() {
 Span.prototype.generateIds = function generateIds() {
     var self = this;
 
-    self.id = self.traceid = [rng.rand(), rng.rand()];
+    self.id = self.traceid = xorshift.randomint();
 };
 
 // Generate just a span id
 Span.prototype.generateSpanid = function generateSpanid() {
     var self = this;
 
-    self.id = [rng.rand(), rng.rand()];
+    self.id = xorshift.randomint();
 };
 
 // ##


### PR DESCRIPTION
The LCG lib was meant to be used for test fixtures only.

Towards #212 

r @Raynos @kriskowal