### PR TITLE
v2/lazy_frame: fix check for valid frame type

### DIFF
--- a/test/v2/lazy_frame.js
+++ b/test/v2/lazy_frame.js
@@ -50,6 +50,27 @@ test('LazyFrame.RW: read/write', testRW.cases(v2.LazyFrame.RW, [
     ]
 ]));
 
+TestBody.testWith('LazyFrame.readFrom, invalid type', function t(assert) {
+    var res = v2.LazyFrame.RW.readFrom(new Buffer([
+        0x00, 0x15,             // size: 2
+        0x50,                   // type: 1
+        0x00,                   // reserved:1
+        0x00, 0x00, 0x00, 0x01, // id:4
+        0x00, 0x00, 0x00, 0x00, // reserved:4
+        0x00, 0x00, 0x00, 0x00, // reserved:4
+
+        0x04, 0x64, 0x6f, 0x67, 0x65 // junk bytes
+    ]), 0);
+
+    var err = res.err;
+
+    assert.equal(err.type, 'tchannel.invalid-frame-type');
+    assert.equal(err.typeNumber, 80);
+
+    assert.end();
+});
+
+
 TestBody.testWith('LazyFrame.readBody', function t(assert) {
     var frame = v2.LazyFrame.RW.readFrom(new Buffer([
         0x00, 0x15,             // size: 2

--- a/v2/lazy_frame.js
+++ b/v2/lazy_frame.js
@@ -102,13 +102,15 @@ function readLazyFrameFrom(buffer, offset) {
     var id = frameBuffer.readUInt32BE(LazyFrame.IdOffset);
 
     var lazyFrame = new LazyFrame(size, type, id, frameBuffer);
-    lazyFrame.bodyRW = Frame.Types[lazyFrame.type].RW;
+    var BodyType = Frame.Types[lazyFrame.type];
 
-    if (!lazyFrame.bodyRW) {
+    if (!BodyType) {
         return bufrw.ReadResult.error(errors.InvalidFrameTypeError({
             typeNumber: lazyFrame.type
         }), offset + LazyFrame.TypeOffset);
     }
+
+    lazyFrame.bodyRW = BodyType.RW;
 
     return bufrw.ReadResult.just(offset, lazyFrame);
 }


### PR DESCRIPTION
Line 105 will just throw if it's an invalid type, so the check for invalid type was ordered incorrectly.

The errors caused look like this:
```
TypeError: Cannot read property 'RW' of undefined
    at BufferRW.readLazyFrameFrom [as readFrom] (/var/cache/udeploy/r/hyperbahn/sjc1-produ-0000000101-v1/node_modules/hyperbahn/node_modules/tchannel/v2/lazy_frame.js:105:51)
    at fromBufferResult (/var/cache/udeploy/r/hyperbahn/sjc1-produ-0000000101-v1/node_modules/hyperbahn/node_modules/bufrw/interface.js:120:18)
    at ReadMachine.seek (/var/cache/udeploy/r/hyperbahn/sjc1-produ-0000000101-v1/node_modules/hyperbahn/node_modules/bufrw/stream/read_machine.js:116:15)
    at ReadMachine.handleChunk (/var/cache/udeploy/r/hyperbahn/sjc1-produ-0000000101-v1/node_modules/hyperbahn/node_modules/bufrw/stream/read_machine.js:67:28)
    at Socket.onSocketChunk (/var/cache/udeploy/r/hyperbahn/sjc1-produ-0000000101-v1/node_modules/hyperbahn/node_modules/tchannel/connection.js:126:29)
    at Socket.emit (events.js:95:17)
    at SocketInspector.inspectEmit (/var/cache/udeploy/r/hyperbahn/sjc1-produ-0000000101-v1/node_modules/hyperbahn/clients/socket-inspector.js:132:23)
    at Socket.boundInspectEmit [as emit] (/var/cache/udeploy/r/hyperbahn/sjc1-produ-0000000101-v1/node_modules/hyperbahn/clients/socket-inspector.js:51:14)
    at Socket.<anonymous> (_stream_readable.js:764:14)
    at Socket.emit (events.js:92:17)
    at SocketInspector.inspectEmit (/var/cache/udeploy/r/hyperbahn/sjc1-produ-0000000101-v1/node_modules/hyperbahn/clients/socket-inspector.js:132:23)
    at Socket.boundInspectEmit [as emit] (/var/cache/udeploy/r/hyperbahn/sjc1-produ-0000000101-v1/node_modules/hyperbahn/clients/socket-inspector.js:51:14)
    at emitReadable_ (_stream_readable.js:426:10)
    at emitReadable (_stream_readable.js:422:5)
    at readableAddChunk (_stream_readable.js:165:9)
    at Socket.Readable.push (_stream_readable.js:127:10)
    at TCP.onread (net.js:528:21)
```

r @jcorbin @Raynos 