### PR TITLE
Support entryPoint in tchannel-as-thrift

### DIFF
--- a/as/thrift.js
+++ b/as/thrift.js
@@ -41,17 +41,22 @@ function TChannelAsThrift(opts) {
 
     var self = this;
 
-    self.thriftSource = opts.source;
-    self.thriftFileName = path.basename(opts.entryPoint || 'service.thrift');
+    assert(opts, 'options required');
+    assert(typeof opts === 'object', 'options must be object');
+
     self.spec = new thriftrw.Thrift({
         entryPoint: opts.entryPoint,
         idls: opts.idls,
-        source: self.thriftSource,
+        source: opts.source,
         strict: opts.strict,
         allowFilesystemAccess: true,
         allowIncludeAlias: opts.allowIncludeAlias,
         fs: opts.fs
     });
+
+    var sources = self.spec.getSources();
+    self.thriftFileName = sources.entryPoint;
+    self.thriftSource = sources.idls[sources.entryPoint];
 
     self.logger = opts.logger;
 

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "safe-json-parse": "^4.0.0",
     "sse4_crc32": "3.2.0",
     "tape-cluster": "2.1.0",
-    "thriftrw": "3.0.1",
+    "thriftrw": "^3.0.2",
     "xorshift": "^0.2.0",
     "xtend": "^4.0.0"
   },

--- a/test/health.js
+++ b/test/health.js
@@ -136,7 +136,6 @@ allocCluster.test('meta returns thrift IDL for the service', {
         if (err) {
             assert.end(err);
         }
-
         assert.ok(res && res.ok, 'res should be ok');
         assert.equals(res.body.entryPoint, 'anechoic-chamber.thrift', 'expect entryPoint to be anechoic-chamber.thrift');
         assert.equals(res.body.idls['anechoic-chamber.thrift'], thriftSource, 'expected IDL should be returned');

--- a/test/hyperbahn-client/thrift-codec.js
+++ b/test/hyperbahn-client/thrift-codec.js
@@ -39,8 +39,11 @@ test('calling getThrift', function t(assert) {
         thriftFile: path.join(__dirname, '..', 'anechoic-chamber.thrift')
     });
 
-    assert.equal(thriftClient.thriftFileName, 'anechoic-chamber.thrift', 'client gets the expected thrift file name');
-    assert.equal(thriftServer.thriftFileName, 'anechoic-chamber.thrift', 'server gets the expected thrift file name');
+    assert.equal(
+        thriftClient.spec.getSources().entryPoint,
+        thriftServer.spec.getSources().entryPoint,
+        'client and server have the same entrypoint'
+    );
 
     thriftServer.register('Chamber::echo', {}, echo);
 


### PR DESCRIPTION
Support entryPoint as well as source.

thriftSource and thriftFilename are no longer properties on tchannel-as-thrift. I don't think these should be exposed as apis. Any objection?