### PR TITLE
Validate host port consistently in listen(), connect(), init handshake

### DIFF
--- a/channel.js
+++ b/channel.js
@@ -45,9 +45,9 @@ var setImmediate = require('timers').setImmediate;
 var globalRandom = Math.random;
 var net = require('net');
 var format = require('util').format;
-
 var inherits = require('util').inherits;
 
+var HostPort = require('./host-port.js');
 var nullLogger = require('./null-logger.js');
 var EndpointHandler = require('./endpoint-handler.js');
 var TChannelRequest = require('./request');
@@ -594,11 +594,21 @@ TChannel.prototype.listen = function listen(port, host, callback) {
     //   available ephemeral port
     // - 127.0.0.1 is a valid host, primarily for testing
     var self = this;
+
     assert(!self.topChannel, 'TChannel must listen on top channel');
     assert(!self.listened, 'TChannel can only listen once');
-    assert(typeof host === 'string', 'TChannel requires host argument');
-    assert(typeof port === 'number', 'TChannel must listen with numeric port');
-    assert(host !== '0.0.0.0', 'TChannel must listen with externally visible host');
+
+    var reason;
+    reason = HostPort.validateHost(host);
+    if (reason) {
+        assert(false, reason);
+    }
+
+    reason = HostPort.validatePort(port, true);
+    if (reason) {
+        assert(false, reason);
+    }
+
     self.listened = true;
     self.requestedPort = port;
     self.host = host;

--- a/docs/channel.md
+++ b/docs/channel.md
@@ -93,6 +93,9 @@ Starts listening on the given port and host.
 
 Both port and host are mandatory.
 
+Port must be a valid port as per [host-port rules](./host-port.md)
+Host must be a valid non-ephemeral host as per [host-port rules](./host-port.md)
+
 The port may be 0, indicating that the operating system must grant an
 available ephemeral port.
 

--- a/docs/channel.md
+++ b/docs/channel.md
@@ -91,12 +91,10 @@ a tcollector reporter that will be wired up for you.
 
 Starts listening on the given port and host.
 
-Both port and host are mandatory.
-
-Port must be a valid port as per [host-port rules](./host-port.md)
-Host must be a valid non-ephemeral host as per [host-port rules](./host-port.md)
-
-The port may be 0, indicating that the operating system must grant an
+ - Both port and host are mandatory.
+ - Port must be a valid port as per [host-port rules](./host-port.md)
+ - Host must be a valid non-ephemeral host as per [host-port rules](./host-port.md)
+ - The port may be 0, indicating that the operating system must grant an
 available ephemeral port.
 
 The eventual host and port combination must uniquely identify the

--- a/docs/host-port.md
+++ b/docs/host-port.md
@@ -1,0 +1,24 @@
+# Valid hostPorts
+
+## What is a valid host
+
+A valid host must be a string containing an IPv4 address.
+The IPv4 address is formatted as `{n}.{n}.{n}.{n}` where `n` is a valid integer.
+
+If the host is non-ephemeral then it must NOT be `0.0.0.0`
+
+## What is a valid port
+
+A valid port must be a integer representing the port.
+The integer must be between 0 and 65536.
+
+If the port is non-ephemeral then it must NOT be `0`
+
+## What is a valid host:port
+
+A valid host:port must be a string containing both the host and port
+The string must be formatted as `{host}:{port}` and must follow
+the host and port rules.
+
+If the host:port is non-ephemeral then it must NOT contain the IP
+`0.0.0.0` and must NOT contain the port `0`

--- a/docs/peer-to-peer.md
+++ b/docs/peer-to-peer.md
@@ -25,6 +25,9 @@ a peer to peer request this is your responsibility
 You can pass in `options.host` to wait for a connection to that
 host to open; your `cb` will be called when it's opened.
 
+`options.host` must be a valid non-ephmeral host port as per the
+[host port rules](./host-port.md)
+
 We may give your `cb` an `err` if the connection failed
 
 ## `subChannel.request({ host: ... })`
@@ -35,6 +38,9 @@ peer request.
 When making an outgoing request on a `subChannel` you can set
 `options.host` to be `'{host}:{port}'` string. This will make
 a direct request to that concrete host.
+
+`options.host` must be a valid non-ephmeral host port as per the
+[host port rules](./host-port.md)
 
 This request is a non-retryable request.
 

--- a/docs/sub-channels.md
+++ b/docs/sub-channels.md
@@ -51,6 +51,9 @@ In the peer to peer use case you will want to specify an array
 of `host:port` strings for all the other instances you want to
 talk to.
 
+The `host:port` strings must be non-ephemeral hostPort as per the
+[host-port rules](./host-port.md)
+
 If you do not specify a `peers` array you must pass a `host`
 option for every outgoing request.
 

--- a/host-port.js
+++ b/host-port.js
@@ -47,7 +47,7 @@ function validatePort(portNum, allowEmphemeral) {
         return 'Expected port to be a number';
     }
 
-    if (portNum < 0 || portNum > 65536) {
+    if (!(portNum >= 0 && portNum < 65536)) {
         return 'Expected port to be between 0 & 65536';
     }
 

--- a/host-port.js
+++ b/host-port.js
@@ -1,0 +1,105 @@
+// Copyright (c) 2015 Uber Technologies, Inc.
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+'use strict';
+
+var HostPort = {
+    validateHostPort: validateHostPort,
+    validateHost: validateHost,
+    validatePort: validatePort
+};
+
+module.exports = HostPort;
+
+function validateHost(host, allowEmphemeral) {
+    if (typeof host !== 'string') {
+        return 'Expected host to be a string';
+    }
+
+    var hostParts = host.split('.');
+    if (hostParts.length !== 4) {
+        return 'Expected host to contain IPv4';
+    }
+
+    var i;
+    for (i = 0; i < 4; i++) {
+        if (!stringIsValidNumber(hostParts[i])) {
+            return 'Expected each IP section to be integer';
+        }
+    }
+
+    if (!allowEmphemeral && host === '0.0.0.0') {
+        return 'Expected host to not be 0.0.0.0';
+    }
+
+    return null;
+}
+
+function validatePort(portNum, allowEmphemeral) {
+    if (typeof portNum !== 'number') {
+        return 'Expected port to be a number';
+    }
+
+    if (portNum < 0 || portNum > 65536) {
+        return 'Expected port to be between 0 & 65536';
+    }
+
+    if (!allowEmphemeral && portNum === 0) {
+        return 'Expected port to not be 0';
+    }
+
+    return null;
+}
+
+function validateHostPort(hostPort, allowEmphemeral) {
+    var reason;
+    if (typeof hostPort !== 'string') {
+        return 'Expected hostPort to be a string';
+    }
+
+    var parts = hostPort.split(':');
+    if (parts.length !== 2) {
+        return 'Expected hostPort to be {ip}:{port}';
+    }
+
+    var host = parts[0];
+    reason = validateHost(host, allowEmphemeral);
+    if (reason) {
+        return reason;
+    }
+
+    var portStr = parts[1];
+    if (!stringIsValidNumber(portStr)) {
+        return 'Expected port to be a valid number';
+    }
+
+    var portNum = parseInt(portStr, 10);
+    reason = validatePort(portNum, allowEmphemeral);
+    if (reason) {
+        return reason;
+    }
+
+    return null;
+}
+
+function stringIsValidNumber(numAsStr) {
+    var num = parseInt(numAsStr, 10);
+    return num.toString() === numAsStr;
+}

--- a/host-port.js
+++ b/host-port.js
@@ -20,13 +20,9 @@
 
 'use strict';
 
-var HostPort = {
-    validateHostPort: validateHostPort,
-    validateHost: validateHost,
-    validatePort: validatePort
-};
-
-module.exports = HostPort;
+module.exports.validateHostPort = validateHostPort;
+module.exports.validateHost = validateHost;
+module.exports.validatePort = validatePort;
 
 function validateHost(host, allowEmphemeral) {
     if (typeof host !== 'string') {

--- a/host-port.js
+++ b/host-port.js
@@ -48,7 +48,7 @@ function validatePort(portNum, allowEmphemeral) {
     }
 
     if (!(portNum >= 0 && portNum < 65536)) {
-        return 'Expected port to be between 0 & 65536';
+        return 'Expected port to be between >=0 & <65536';
     }
 
     if (!allowEmphemeral && portNum === 0) {

--- a/host-port.js
+++ b/host-port.js
@@ -66,7 +66,7 @@ function validateHostPort(hostPort, allowEmphemeral) {
 
     var parts = hostPort.split(':');
     if (parts.length !== 2) {
-        return 'Expected hostPort to be {ip}:{port}';
+        return 'Expected hostPort to be {ipv4}:{port}';
     }
 
     var host = parts[0];

--- a/host-port.js
+++ b/host-port.js
@@ -20,6 +20,8 @@
 
 'use strict';
 
+var validIPv4 = /\d+\.\d+\.\d+\.\d+/;
+
 module.exports.validateHostPort = validateHostPort;
 module.exports.validateHost = validateHost;
 module.exports.validatePort = validatePort;
@@ -29,16 +31,8 @@ function validateHost(host, allowEmphemeral) {
         return 'Expected host to be a string';
     }
 
-    var hostParts = host.split('.');
-    if (hostParts.length !== 4) {
+    if (!validIPv4.test(host)) {
         return 'Expected host to contain IPv4';
-    }
-
-    var i;
-    for (i = 0; i < 4; i++) {
-        if (!stringIsValidNumber(hostParts[i])) {
-            return 'Expected each IP section to be integer';
-        }
     }
 
     if (!allowEmphemeral && host === '0.0.0.0') {

--- a/host-port.js
+++ b/host-port.js
@@ -20,7 +20,7 @@
 
 'use strict';
 
-var validIPv4 = /\d+\.\d+\.\d+\.\d+/;
+var validIPv4 = /^\d+\.\d+\.\d+\.\d+$/;
 
 module.exports.validateHostPort = validateHostPort;
 module.exports.validateHost = validateHost;

--- a/peer.js
+++ b/peer.js
@@ -28,6 +28,7 @@ var stat = require('./stat-tags.js');
 var net = require('net');
 
 var TChannelConnection = require('./connection');
+var HostPort = require('./host-port.js');
 var errors = require('./errors');
 var Request = require('./request');
 var PreferOutgoing = require('./peer_score_strategies.js').PreferOutgoing;
@@ -562,13 +563,20 @@ TChannelPeer.prototype.removeConnection = function removeConnection(conn) {
 
 TChannelPeer.prototype.makeOutSocket = function makeOutSocket() {
     var self = this;
+
+    var reason = HostPort.validateHostPort(self.hostPort, false);
+    if (reason) {
+        assert(false, reason);
+    }
+
     var parts = self.hostPort.split(':');
-    assert(parts.length === 2, 'invalid destination ' + self.hostPort);
     var host = parts[0];
-    var port = parts[1];
-    assert(host !== '0.0.0.0', 'cannot connect to ephemeral peer');
-    assert(port !== '0', 'cannot connect to dynamic port');
-    var socket = net.createConnection({host: host, port: port});
+    var port = parseInt(parts[1], 10);
+
+    var socket = net.createConnection({
+        host: host,
+        port: port
+    });
     return socket;
 };
 

--- a/test/tchannel.js
+++ b/test/tchannel.js
@@ -133,7 +133,7 @@ test('make socket: should throw for invalid destination', function t(assert) {
   server.listen(serverOptions.port, serverOptions.host, function listening() {
     assert.throws(function () {
       server.peers.add('localhost').connect();
-    }, /invalid destination/,
+    }, /Expected hostPort to be {ip}:{port}/,
       'Should reject invalid destination');
     server.quit(assert.end);
   });


### PR DESCRIPTION
This change introduces a `HostPort.validateX()` helper to allows consistent
validation of host & port concerns in all places we care.

I'll update this PR with actual markdown documentation real soon now.

@wolski asked us to clearly document what a `hostPort` actually means and
this consistent validation & documentation should help with that.

r: @rf @jcorbin