### PR TITLE
out_req: only mark end on last call response frame

### DIFF
--- a/out_request.js
+++ b/out_request.js
@@ -268,7 +268,7 @@ TChannelOutRequest.prototype.emitResponse = function emitResponse(res) {
         self.res.finishEvent.on(onFinished);
     }
 
-    self.responseEvent.emit(self, res);
+    self.responseEvent.emit(self, self.res);
 
     function onFinished() {
         self.markEnd();

--- a/out_request.js
+++ b/out_request.js
@@ -259,6 +259,25 @@ TChannelOutRequest.prototype.extendLogInfo = function extendLogInfo(info) {
 TChannelOutRequest.prototype.emitResponse = function emitResponse(res) {
     var self = this;
 
+    self.res = res;
+    self.res.span = self.span;
+
+    if (!self.res.streamed) {
+        self.markEnd();
+    } else {
+        self.res.finishEvent.on(onFinished);
+    }
+
+    self.responseEvent.emit(self, res);
+
+    function onFinished() {
+        self.markEnd();
+    }
+};
+
+TChannelOutRequest.prototype.markEnd = function markEnd() {
+    var self = this;
+
     self.peer.invalidateScore('outreq.emitResponse');
 
     if (self.end) {
@@ -274,13 +293,8 @@ TChannelOutRequest.prototype.emitResponse = function emitResponse(res) {
         self.end = self.channel.timers.now();
     }
 
-    self.res = res;
-    self.res.span = self.span;
-
     self.emitPerAttemptLatency();
-    self.emitPerAttemptResponseStat(res);
-
-    self.responseEvent.emit(self, res);
+    self.emitPerAttemptResponseStat(self.res);
 };
 
 TChannelOutRequest.prototype.sendParts = function sendParts(parts, isLast) {


### PR DESCRIPTION
This fixes a bug where we reported latency on the
first call response frame instead of the last call
response frame.

This was naughty.

r: @kriskowal @rf @jcorbin