### PR TITLE
Fix a race conditions in operations.sanitySweep()

### DIFF
--- a/operations.js
+++ b/operations.js
@@ -512,7 +512,7 @@ Operations.prototype._sweepOps = function _sweepOps(ops, direction, callback) {
                 direction: direction,
                 id: id
             });
-        } else if (op.timedOut) {
+        } else if (op && op.timedOut) {
             self.logger.warn('lingering timed-out operation', {
                 direction: direction,
                 id: id
@@ -525,7 +525,7 @@ Operations.prototype._sweepOps = function _sweepOps(ops, direction, callback) {
                 self.popOutReq(id);
                 pendingDirty = true;
             }
-        } else if (op.isTombstone) {
+        } else if (op && op.isTombstone) {
             var heap = self.connection.channel.timeHeap;
             var expireTime = op.time + op.timeout;
 

--- a/operations.js
+++ b/operations.js
@@ -506,7 +506,8 @@ Operations.prototype._sweepOps = function _sweepOps(ops, direction, callback) {
 
         var id = opKeys[i];
         var op = ops[id];
-        if (op === undefined) {
+
+        if (op === undefined && (id in ops)) {
             self.logger.warn('unexpected undefined operation', {
                 direction: direction,
                 id: id


### PR DESCRIPTION
Because of nextTicks its possible for the cached `opKeys`
array and the `ops` object disagree about the state of the
world.

This is why I skip over any keys in `opKeys` that are not
own propertys of `ops`

r: @jcorbin @kriskowal @rf