### PR TITLE
WIP: as/json: ensure arg2 headers are map<string, string>

### DIFF
--- a/as/json.js
+++ b/as/json.js
@@ -242,10 +242,31 @@ TChannelJSON.prototype.register = function register(
     }
 };
 
+function stringifyArg2(headers) {
+    headers = headers || {};
+
+    var keys = Object.keys(headers);
+
+    for (var i = 0; i < keys.length; i++) {
+        var fieldName = keys[i];
+        var headerValue = headers[fieldName];
+
+        if (typeof headerValue !== 'string') {
+            var err = new Error(
+                'Expected json arg2 to be strings.\n' +
+                'Found a `' + typeof headerValue + '` for header: ' + fieldName
+            );
+            return new Result(err);
+        }
+    }
+
+    return safeJSONStringify(headers);
+}
+
 TChannelJSON.prototype._stringify = function stringify(opts) {
     var self = this;
 
-    var headR = safeJSONStringify(opts.head);
+    var headR = stringifyArg2(opts.head);
     if (headR.err) {
         var headStringifyErr = errors.JSONHeadStringifyError(headR.err, {
             endpoint: opts.endpoint,

--- a/test/as-json.js
+++ b/test/as-json.js
@@ -57,7 +57,7 @@ allocCluster.test('getting an ok response', {
 
         assert.deepEqual(resp, {
             ok: true,
-            head: null,
+            head: {},
             headers: {
                 'as': 'json'
             },
@@ -123,7 +123,7 @@ allocCluster.test('getting a notOk response', {
 
         assert.deepEqual(resp, {
             ok: false,
-            head: null,
+            head: {},
             headers: {
                 'as': 'json'
             },


### PR DESCRIPTION
We have inconsistencies in our implementations.

Updating node to enforce that arg2 is not an arbitrary
JSON expression.

See change for python as well: https://github.com/uber/tchannel-python/pull/339

r: @kriskowal @rf @abhinav @breerly
