### PR TITLE
add TChannelThrift.parseException()

### DIFF
--- a/as/thrift.js
+++ b/as/thrift.js
@@ -167,7 +167,7 @@ TChannelAsThrift.prototype.request = function request(reqOptions) {
         reqOptions.type !== 'tchannel.outgoing-request',
         'invalid reqOptions to TChannelAsThrift.request');
 
-    var shouldApplicationRetry = reqOptions.shouldApplicationRetry;
+    var shouldApplicationRetry = reqOptions.shouldThriftRetry;
     if (shouldApplicationRetry) {
         reqOptions.shouldApplicationRetry = wrappedShouldRetry;
     }
@@ -180,8 +180,8 @@ TChannelAsThrift.prototype.request = function request(reqOptions) {
 
     return req;
 
-    function wrappedShouldRetry(req, res, retry, done) {
-        self.parseException(req, res, onException);
+    function wrappedShouldRetry(req2, res, retry, done) {
+        self.parseException(req2, res, onException);
 
         function onException(err, info) {
             if (err) {

--- a/as/thrift.js
+++ b/as/thrift.js
@@ -100,6 +100,44 @@ function registerHealthAsync() {
     }
 };
 
+TChannelAsThrift.prototype.parseException =
+function parseException(request, response, cb) {
+    var self = this;
+
+    if (response.streamed) {
+        response.arg3.onValueReady(onArgReady);
+    } else {
+        parseArg3(response.arg3);
+    }
+
+    function onArgReady(err, arg3) {
+        if (err) {
+            return cb(err);
+        }
+
+        parseArg3(arg3);
+    }
+
+    function parseArg3(arg3) {
+        var parseResult = self._parse({
+            head: null,
+            body: arg3,
+            ok: false,
+            endpoint: request.endpoint,
+            direction: 'in.response'
+        });
+        if (parseResult.err) {
+            return cb(parseResult.err);
+        }
+
+        var v = parseResult.value;
+        cb(null, {
+            exception: v.body,
+            typeName: v.typeName
+        });
+    }
+};
+
 TChannelAsThrift.prototype.registerHealthSync =
 function registerHealthSync() {
     var self = this;
@@ -310,25 +348,30 @@ TChannelAsThrift.prototype._parse = function parse(opts) {
     var returnName = opts.endpoint + '_result';
     var resultType = spec.getType(returnName);
 
-    var headRes = bufrw.fromBufferResult(HeaderRW, opts.head);
-    if (headRes.err) {
-        var headParseErr = errors.ThriftHeadParserError(headRes.err, {
-            endpoint: opts.endpoint,
-            direction: opts.direction,
-            ok: opts.ok,
-            headBuf: opts.head.slice(0, 10)
-        });
-
-        if (self.logParseFailures) {
-            self.logger.warn('Got unexpected invalid thrift arg2', {
+    var headRes;
+    if (!opts.head) {
+        headRes = new Result(null, null);
+    } else {
+        headRes = bufrw.fromBufferResult(HeaderRW, opts.head);
+        if (headRes.err) {
+            var headParseErr = errors.ThriftHeadParserError(headRes.err, {
                 endpoint: opts.endpoint,
                 direction: opts.direction,
                 ok: opts.ok,
-                headErr: headParseErr
+                headBuf: opts.head.slice(0, 10)
             });
-        }
 
-        return new Result(headParseErr);
+            if (self.logParseFailures) {
+                self.logger.warn('Got unexpected invalid thrift arg2', {
+                    endpoint: opts.endpoint,
+                    direction: opts.direction,
+                    ok: opts.ok,
+                    headErr: headParseErr
+                });
+            }
+
+            return new Result(headParseErr);
+        }
     }
 
     var bodyRes;

--- a/request.js
+++ b/request.js
@@ -486,6 +486,7 @@ TChannelRequest.prototype.maybeAppRetry = function maybeAppRetry(res) {
         if (self.checkTimeout(null, res)) {
             return;
         }
+
         self.deferResend();
     }
 

--- a/test/as-thrift.js
+++ b/test/as-thrift.js
@@ -244,33 +244,6 @@ allocCluster.test('send and receive a typed notOk', {
     });
 });
 
-allocCluster.test('send and receive a typed notOk', {
-    numPeers: 2
-}, function t(cluster, assert) {
-    var tchannelAsThrift = makeTChannelThriftServer(cluster, {
-        notOkTypedResponse: true
-    });
-
-    var client = cluster.channels[1].subChannels.server;
-
-    tchannelAsThrift.send(client.request({
-        serviceName: 'server',
-        hasNoParent: true
-    }), 'Chamber::echo', null, {
-        value: 10
-    }, function onResponse(err, res) {
-        assert.ifError(err);
-
-        assert.ok(!res.ok);
-
-        assert.equal(res.body.value, 10);
-        assert.equal(res.body.message, 'No echo typed error');
-        assert.equal(res.body.type, 'server.no-echo');
-
-        assert.end();
-    });
-});
-
 allocCluster.test('sending and receiving headers', {
     numPeers: 2
 }, function t(cluster, assert) {

--- a/test/as-thrift.js
+++ b/test/as-thrift.js
@@ -166,8 +166,8 @@ allocCluster.test('as=thrift send supports shouldApplicationRetry', {
                 return done(err);
             }
 
-            assert.equal(info.exception.value, 10);
-            assert.equal(info.exception.message, 'No echo');
+            assert.equal(info.body.value, 10);
+            assert.equal(info.body.message, 'No echo');
             assert.equal(info.typeName, 'noEcho');
 
             if (info.typeName === 'noEcho') {
@@ -204,16 +204,16 @@ allocCluster.test('as=thrift request supports shouldApplicationRetry', {
         assert.end();
     });
 
-    function shouldRetry(req, res, info, retry, done) {
-        assert.equal(info.exception.value, 10);
-        assert.equal(info.exception.message, 'No echo');
-        assert.equal(info.typeName, 'noEcho');
+    function shouldRetry(res/*, rawReq, rawRes*/) {
+        assert.equal(res.body.value, 10);
+        assert.equal(res.body.message, 'No echo');
+        assert.equal(res.typeName, 'noEcho');
 
-        if (info.typeName === 'noEcho') {
-            return retry();
+        if (res.typeName === 'noEcho') {
+            return true;
         }
 
-        done();
+        return false;
     }
 });
 

--- a/test/as-thrift.js
+++ b/test/as-thrift.js
@@ -191,7 +191,7 @@ allocCluster.test('as=thrift request supports shouldApplicationRetry', {
     tchannelAsThrift.request({
         serviceName: 'server',
         hasNoParent: true,
-        shouldApplicationRetry: shouldRetry
+        shouldThriftRetry: shouldRetry
     }).send('Chamber::echo', null, {
         value: 10
     }, function onResponse(err, res) {

--- a/test/as-thrift.js
+++ b/test/as-thrift.js
@@ -130,6 +130,82 @@ allocCluster.test('send and receive a notOk', {
     });
 });
 
+allocCluster.test('as=thrift supports shouldApplicationRetry', {
+    numPeers: 3
+}, function t(cluster, assert) {
+    var tchannelAsThrift = makeTChannelThriftServer(cluster, {
+        notOkResponse: true,
+        succeedSecondTime: true,
+        servers: 2
+    });
+
+    var client = cluster.channels[2].subChannels.server;
+
+    tchannelAsThrift.send(client.request({
+        serviceName: 'server',
+        hasNoParent: true,
+        shouldApplicationRetry: shouldRetry
+    }), 'Chamber::echo', null, {
+        value: 10
+    }, function onResponse(err, res) {
+        assert.ifError(err);
+
+        assert.ok(res.ok);
+        assert.equal(res.body, 10);
+        assert.equal(res.headers.as, 'thrift');
+
+        assert.end();
+    });
+
+    function shouldRetry(req, res, retry, done) {
+        tchannelAsThrift.parseException(req, res, onException);
+
+        function onException(err, info) {
+            // Failed to parse thrift response
+            if (err) {
+                return done(err);
+            }
+
+            assert.equal(info.exception.value, 10);
+            assert.equal(info.exception.message, 'No echo');
+            assert.equal(info.typeName, 'noEcho');
+
+            if (info.typeName === 'noEcho') {
+                return retry();
+            }
+
+            done();
+        }
+    }
+});
+
+allocCluster.test('send and receive a typed notOk', {
+    numPeers: 2
+}, function t(cluster, assert) {
+    var tchannelAsThrift = makeTChannelThriftServer(cluster, {
+        notOkTypedResponse: true
+    });
+
+    var client = cluster.channels[1].subChannels.server;
+
+    tchannelAsThrift.send(client.request({
+        serviceName: 'server',
+        hasNoParent: true
+    }), 'Chamber::echo', null, {
+        value: 10
+    }, function onResponse(err, res) {
+        assert.ifError(err);
+
+        assert.ok(!res.ok);
+
+        assert.equal(res.body.value, 10);
+        assert.equal(res.body.message, 'No echo typed error');
+        assert.equal(res.body.type, 'server.no-echo');
+
+        assert.end();
+    });
+});
+
 allocCluster.test('send and receive a typed notOk', {
     numPeers: 2
 }, function t(cluster, assert) {
@@ -448,8 +524,8 @@ allocCluster.test('using register() without channel', {
     }
 });
 
-function makeTChannelThriftServer(cluster, opts) {
-    var server = cluster.channels[0].makeSubChannel({
+function makeActualServer(channel, opts) {
+    var server = channel.makeSubChannel({
         serviceName: 'server'
     });
     var NoEchoTypedError = TypedError({
@@ -458,21 +534,11 @@ function makeTChannelThriftServer(cluster, opts) {
         value: null
     });
 
-    cluster.channels[1].makeSubChannel({
-        serviceName: 'server',
-        peers: [
-            cluster.channels[0].hostPort
-        ],
-        requestDefaults: {
-            headers: {
-                cn: 'wat'
-            }
-        }
-    });
-
     var options = {
         isOptions: true
     };
+
+    var succeedSecondTime = opts.succeedSecondTime;
 
     var fn = opts.okResponse ? okHandler :
         opts.notOkResponse ? notOkHandler :
@@ -480,17 +546,14 @@ function makeTChannelThriftServer(cluster, opts) {
         opts.networkFailureResponse ? networkFailureHandler :
             networkFailureHandler;
 
-    var tchannelAsThrift = cluster.channels[0].TChannelAsThrift({
+    var tchannelAsThrift = channel.TChannelAsThrift({
         entryPoint: path.join(__dirname, 'anechoic-chamber.thrift'),
-        logParseFailures: false,
-        channel: cluster.channels[1].subChannels.server
+        logParseFailures: false
     });
     tchannelAsThrift.register(server, 'Chamber::echo', options, fn);
     tchannelAsThrift.register(server, 'Chamber::echo_big', options, echoBig);
 
-    return tchannelAsThrift;
-
-    function echoBig(opts, req, head, body, cb) {
+    function echoBig(ctx, req, head, body, cb) {
         return cb(null, {
             ok: true,
             head: null,
@@ -498,7 +561,7 @@ function makeTChannelThriftServer(cluster, opts) {
         });
     }
 
-    function okHandler(opts, req, head, body, cb) {
+    function okHandler(ctx, req, head, body, cb) {
         return cb(null, {
             ok: true,
             head: head,
@@ -506,7 +569,16 @@ function makeTChannelThriftServer(cluster, opts) {
         });
     }
 
-    function notOkHandler(opts, req, head, body, cb) {
+    function notOkHandler(ctx, req, head, body, cb) {
+        opts.count++;
+        if (opts.count === 2 && succeedSecondTime) {
+            return cb(null, {
+                ok: true,
+                head: null,
+                body: body.value
+            });
+        }
+
         return cb(null, {
             ok: false,
             body: NoEchoError(body.value),
@@ -514,7 +586,7 @@ function makeTChannelThriftServer(cluster, opts) {
         });
     }
 
-    function notOkTypedHandler(opts, req, head, body, cb) {
+    function notOkTypedHandler(ctx, req, head, body, cb) {
         cb(null, {
             ok: false,
             body: NoEchoTypedError({
@@ -524,7 +596,7 @@ function makeTChannelThriftServer(cluster, opts) {
         });
     }
 
-    function networkFailureHandler(opts, req, head, body, cb) {
+    function networkFailureHandler(ctx, req, head, body, cb) {
         var networkError = new Error('network failure');
 
         cb(networkError);
@@ -535,4 +607,35 @@ function makeTChannelThriftServer(cluster, opts) {
         err.value = value;
         return err;
     }
+}
+
+function makeTChannelThriftServer(cluster, opts) {
+    var servers = opts.servers || 1;
+    opts.count = opts.count || 0;
+
+    var clientIndex = servers;
+    var peers = [];
+
+    for (var i = 0; i < servers; i++) {
+        makeActualServer(cluster.channels[i], opts);
+        peers.push(cluster.channels[i].hostPort);
+    }
+
+    cluster.channels[clientIndex].makeSubChannel({
+        serviceName: 'server',
+        peers: peers,
+        requestDefaults: {
+            headers: {
+                cn: 'wat'
+            }
+        }
+    });
+
+    var tchannelAsThrift = cluster.channels[clientIndex].TChannelAsThrift({
+        entryPoint: path.join(__dirname, 'anechoic-chamber.thrift'),
+        logParseFailures: false,
+        channel: cluster.channels[clientIndex].subChannels.server
+    });
+
+    return tchannelAsThrift;
 }


### PR DESCRIPTION
Enabled application developers to hook into our shouldAppRetry
logic when doing thrift encoded stuff.

It's kind of hard to actually expose it "optimally" but at
least exposing a `parseException()` method allows people to
get the job done.

r: @jcorbin @kriskowal @malandrew