### PR TITLE
handle case where there simply is no conn

### DIFF
--- a/lazy_relay.js
+++ b/lazy_relay.js
@@ -213,6 +213,12 @@ function onIdentified(err) {
     }
 
     var conn = self.peer.getInConnection(true);
+    if (!conn) {
+        self.logger.warn('onIdentified called on non-existing connection', self.extendLogInfo({}));
+        self.onError(errors.NoPeerAvailable());
+        return;
+    }
+
     if (!conn.remoteName) {
         // we get the problem
         self.logger.warn('onIdentified called on unidentified connection', self.extendLogInfo({}));

--- a/lazy_relay.js
+++ b/lazy_relay.js
@@ -214,18 +214,27 @@ function onIdentified(err) {
 
     var conn = self.peer.getInConnection(true);
     if (!conn) {
-        self.logger.warn('onIdentified called on non-existing connection', self.extendLogInfo({}));
+        self.logger.warn(
+            'onIdentified called on non-existing connection',
+            self.extendLogInfo(self.peer.extendLogInfo({}))
+        );
         self.onError(errors.NoPeerAvailable());
         return;
     }
 
     if (!conn.remoteName) {
         // we get the problem
-        self.logger.warn('onIdentified called on unidentified connection', self.extendLogInfo({}));
+        self.logger.warn(
+            'onIdentified called on unidentified connection',
+            self.extendLogInfo(self.peer.extendLogInfo({}))
+        );
     }
     if (conn.closing) {
         // most likely
-        self.logger.warn('onIdentified called on closing connection', self.extendLogInfo({}));
+        self.logger.warn(
+            'onIdentified called on closing connection',
+            self.extendLogInfo(self.peer.extendLogInfo({}))
+        );
     }
 
     self.forwardTo(conn);

--- a/peer.js
+++ b/peer.js
@@ -145,6 +145,10 @@ function extendLogInfo(info) {
     info.peerDraining = !!self.draining;
     info.scoreRange = self.scoreRange;
 
+    if (self.draining) {
+        self.draining.extendLogInfo(info);
+    }
+
     return info;
 };
 


### PR DESCRIPTION
I've seen this uncaught in prod where `conn` is undefined.

Not really sure what to do here. for now its a logger.warn()
and No peer available.

r: @jcorbin @kriskowal