### PR TITLE
Drop new-less support from many internal classes

### DIFF
--- a/argstream.js
+++ b/argstream.js
@@ -134,9 +134,6 @@ InArgStream.prototype.handleFrame = function handleFrame(parts, isLast) {
 };
 
 function OutArgStream() {
-    if (!(this instanceof OutArgStream)) {
-        return new OutArgStream();
-    }
     var self = this;
     ArgStream.call(self);
     self._flushImmed = null;

--- a/argstream.js
+++ b/argstream.js
@@ -246,8 +246,12 @@ function StreamArg(options) {
     var self = this;
     PassThrough.call(self, options);
     self.started = false;
-    self.onValueReady = self.onValueReady.bind(self);
     self.buf = null;
+    self.onValueReady = boundOnValueReady;
+
+    function boundOnValueReady(callback) {
+        self._onValueReady(callback);
+    }
 }
 inherits(StreamArg, PassThrough);
 
@@ -260,7 +264,7 @@ StreamArg.prototype._write = function _write(chunk, encoding, callback) {
     PassThrough.prototype._write.call(self, chunk, encoding, callback);
 };
 
-StreamArg.prototype.onValueReady = function onValueReady(callback) {
+StreamArg.prototype._onValueReady = function onValueReady(callback) {
     var self = this;
     self.onValueReady = Ready();
     bufferStreamData(self, self.onValueReady.signal);

--- a/argstream.js
+++ b/argstream.js
@@ -146,24 +146,32 @@ function OutArgStream() {
     self.finished = false;
     self.frame = [Buffer(0)];
     self.currentArgN = 2;
-    self.arg2.on('data', function onArg2Data(chunk) {
-        self._handleFrameChunk(2, chunk);
-    });
-    self.arg3.on('data', function onArg3Data(chunk) {
-        self._handleFrameChunk(3, chunk);
-    });
 
-    self.arg2.on('finish', function onArg2Finish() {
+    self.arg2.on('data', onArg2Data);
+    self.arg3.on('data', onArg3Data);
+    self.arg2.on('finish', onArg2Finish);
+    self.arg3.on('finish', onArg3Finish);
+
+    function onArg2Data(chunk) {
+        self._handleFrameChunk(2, chunk);
+    }
+
+    function onArg3Data(chunk) {
+        self._handleFrameChunk(3, chunk);
+    }
+
+    function onArg2Finish() {
         self._handleFrameChunk(2, null);
-    });
-    self.arg3.on('finish', function onArg3Finish() {
+    }
+
+    function onArg3Finish() {
         if (!self.finished) {
             self._handleFrameChunk(3, null);
             self._flushParts(true);
             self.finished = true;
             self.finishEvent.emit(self);
         }
-    });
+    }
 }
 
 inherits(OutArgStream, ArgStream);

--- a/argstream.js
+++ b/argstream.js
@@ -74,9 +74,6 @@ function ArgStream() {
 inherits(ArgStream, EventEmitter);
 
 function InArgStream() {
-    if (!(this instanceof InArgStream)) {
-        return new InArgStream();
-    }
     var self = this;
     ArgStream.call(self);
     self.streams = [self.arg2, self.arg3];

--- a/argstream.js
+++ b/argstream.js
@@ -53,8 +53,8 @@ function ArgStream() {
     self.frameEvent = self.defineEvent('frame');
     self.finishEvent = self.defineEvent('finish');
 
-    self.arg2 = StreamArg();
-    self.arg3 = StreamArg();
+    self.arg2 = new StreamArg();
+    self.arg3 = new StreamArg();
 
     self.arg2.on('error', passError);
     self.arg3.on('error', passError);
@@ -234,9 +234,6 @@ OutArgStream.prototype._flushParts = function _flushParts(isLast) {
 };
 
 function StreamArg(options) {
-    if (!(this instanceof StreamArg)) {
-        return new StreamArg(options);
-    }
     var self = this;
     PassThrough.call(self, options);
     self.started = false;

--- a/argstream.js
+++ b/argstream.js
@@ -58,15 +58,17 @@ function ArgStream() {
 
     self.arg2.on('error', passError);
     self.arg3.on('error', passError);
+    self.arg3.on('start', onArg3Start);
+
     function passError(err) {
         self.errorEvent.emit(self, err);
     }
 
-    self.arg3.on('start', function onArg3Start() {
+    function onArg3Start() {
         if (!self.arg2._writableState.ended) {
             self.arg2.end();
         }
-    });
+    }
 }
 
 inherits(ArgStream, EventEmitter);

--- a/channel.js
+++ b/channel.js
@@ -176,9 +176,9 @@ function TChannel(options) {
     // - incoming connections on any listening socket
 
     if (!self.topChannel) {
-        self.peers = TChannelRootPeers(self, self.options);
+        self.peers = new TChannelRootPeers(self, self.options);
     } else {
-        self.peers = TChannelSubPeers(self, self.options);
+        self.peers = new TChannelSubPeers(self, self.options);
     }
 
     // For tracking the number of pending requests to any service

--- a/lib/statsd.js
+++ b/lib/statsd.js
@@ -31,10 +31,6 @@ BatchStatsd.BaseStat = BaseStat;
 var LENGTH_ARRAYS = {};
 
 function BatchStatsd(options) {
-    if (!(this instanceof BatchStatsd)) {
-        return new BatchStatsd(options);
-    }
-
     var self = this;
 
     assert(options.logger, 'options.logger required');

--- a/peer.js
+++ b/peer.js
@@ -43,9 +43,6 @@ var DEFAULT_REPORT_INTERVAL = 1000;
 function TChannelPeer(channel, hostPort, options) {
     assert(hostPort !== '0.0.0.0:0', 'Cannot create ephemeral peer');
 
-    if (!(this instanceof TChannelPeer)) {
-        return new TChannelPeer(channel, hostPort, options);
-    }
     var self = this;
     options = options || {};
     EventEmitter.call(self);

--- a/root_peers.js
+++ b/root_peers.js
@@ -93,7 +93,7 @@ TChannelRootPeers.prototype.getSelfPeer = function getSelfPeer() {
     var self = this;
 
     if (!self.selfPeer) {
-        self.selfPeer = TChannelSelfPeer(self.channel);
+        self.selfPeer = new TChannelSelfPeer(self.channel);
     }
     return self.selfPeer;
 };
@@ -113,7 +113,7 @@ TChannelRootPeers.prototype.add = function add(hostPort, options) {
 
     options = options || extend({}, self.peerOptions);
     options.preferConnectionDirection = self.preferConnectionDirection;
-    peer = TChannelPeer(self.channel, hostPort, options);
+    peer = new TChannelPeer(self.channel, hostPort, options);
     self.allocPeerEvent.emit(self, peer);
 
     self._map[hostPort] = peer;

--- a/root_peers.js
+++ b/root_peers.js
@@ -29,10 +29,6 @@ var TChannelPeer = require('./peer');
 var TChannelSelfPeer = require('./self_peer');
 
 function TChannelRootPeers(channel, options) {
-    if (!(this instanceof TChannelRootPeers)) {
-        return new TChannelRootPeers(channel, options);
-    }
-
     var self = this;
     TChannelPeersBase.call(self, channel, options);
 

--- a/self_connection.js
+++ b/self_connection.js
@@ -32,9 +32,6 @@ var process = require('process');
 var TChannelConnectionBase = require('./connection_base');
 
 function TChannelSelfConnection(channel) {
-    if (!(this instanceof TChannelSelfConnection)) {
-        return new TChannelSelfConnection(channel);
-    }
     var self = this;
     TChannelConnectionBase.call(self, channel, 'in', channel.hostPort);
     self.idCount = 1;

--- a/self_peer.js
+++ b/self_peer.js
@@ -27,11 +27,7 @@ var TChannelPeer = require('./peer');
 var TChannelSelfConnection = require('./self_connection');
 
 function TChannelSelfPeer(channel) {
-    if (!(this instanceof TChannelSelfPeer)) {
-        return new TChannelSelfPeer(channel);
-    }
-    var self = this;
-    TChannelPeer.call(self, channel, channel.hostPort);
+    TChannelPeer.call(this, channel, channel.hostPort);
 }
 inherits(TChannelSelfPeer, TChannelPeer);
 

--- a/self_peer.js
+++ b/self_peer.js
@@ -39,7 +39,7 @@ TChannelSelfPeer.prototype.connect = function connect() {
     }
     var conn = self.connections[0];
     if (!conn) {
-        conn = TChannelSelfConnection(self.channel);
+        conn = new TChannelSelfConnection(self.channel);
         self.addConnection(conn);
     }
     return conn;

--- a/streaming_in_request.js
+++ b/streaming_in_request.js
@@ -36,7 +36,7 @@ function StreamingInRequest(id, options) {
     InRequest.call(self, id, options);
 
     self.streamed = true;
-    self._argstream = InArgStream();
+    self._argstream = new InArgStream();
     self.arg2 = self._argstream.arg2;
     self.arg3 = self._argstream.arg3;
 

--- a/streaming_in_response.js
+++ b/streaming_in_response.js
@@ -37,7 +37,7 @@ function StreamingInResponse(id, options) {
     InResponse.call(self, id, options);
 
     self.streamed = true;
-    self._argstream = InArgStream();
+    self._argstream = new InArgStream();
     self.arg2 = self._argstream.arg2;
     self.arg3 = self._argstream.arg3;
     self._argstream.errorEvent.on(passError);

--- a/streaming_out_request.js
+++ b/streaming_out_request.js
@@ -31,7 +31,7 @@ function StreamingOutRequest(id, options) {
     var self = this;
     TChannelOutRequest.call(self, id, options);
     self.streamed = true;
-    self._argstream = OutArgStream();
+    self._argstream = new OutArgStream();
     self.arg2 = self._argstream.arg2;
     self.arg3 = self._argstream.arg3;
     self._argstream.errorEvent.on(passError);

--- a/streaming_out_response.js
+++ b/streaming_out_response.js
@@ -32,7 +32,7 @@ function StreamingOutResponse(id, options) {
     var self = this;
     OutResponse.call(self, id, options);
     self.streamed = true;
-    self._argstream = OutArgStream();
+    self._argstream = new OutArgStream();
     self.arg2 = self._argstream.arg2;
     self.arg3 = self._argstream.arg3;
     self._argstream.errorEvent.on(passError);

--- a/sub_peers.js
+++ b/sub_peers.js
@@ -26,9 +26,6 @@ var TChannelPeersBase = require('./peers_base.js');
 var PeerHeap = require('./peer_heap.js');
 
 function TChannelSubPeers(channel, options) {
-    if (!(this instanceof TChannelSubPeers)) {
-        return new TChannelSubPeers(channel, options);
-    }
     var self = this;
     TChannelPeersBase.call(self, channel, options);
 

--- a/test/v2/args.js
+++ b/test/v2/args.js
@@ -37,7 +37,7 @@ function TestBody(csum, args) {
 }
 
 TestBody.RW = bufrw.Struct(TestBody, [
-    {call: ArgsRW(bufrw.buf2)}
+    {call: new ArgsRW(bufrw.buf2)}
 ]);
 
 test('ArgsRW: read/write payload', testRW.cases(TestBody.RW, [

--- a/trace/agent.js
+++ b/trace/agent.js
@@ -26,9 +26,6 @@ var errors = require('../errors.js');
 module.exports = Agent;
 
 function Agent(options) {
-    if (!(this instanceof Agent)) {
-        return new Agent(options);
-    }
     var self = this;
 
     options = options || {};

--- a/trace/span.js
+++ b/trace/span.js
@@ -28,9 +28,6 @@ module.exports.Annotation = Annotation;
 module.exports.BinaryAnnotation = BinaryAnnotation;
 
 function Span(options) {
-    if (!(this instanceof Span)) {
-        return new Span(options);
-    }
     var self = this;
 
     // TODO: options validation
@@ -133,9 +130,6 @@ function annotateBinary(key, value, type) {
 };
 
 function Endpoint(ipv4, port, serviceName) {
-    if (!(this instanceof Endpoint)) {
-        return new Endpoint(ipv4, port, serviceName);
-    }
     var self = this;
 
     self.ipv4 = ipv4;
@@ -144,9 +138,6 @@ function Endpoint(ipv4, port, serviceName) {
 }
 
 function Annotation(value, host, timestamp) {
-    if (!(this instanceof Annotation)) {
-        return new Annotation(value, host, timestamp);
-    }
     var self = this;
 
     // TODO: validation
@@ -157,9 +148,6 @@ function Annotation(value, host, timestamp) {
 }
 
 function BinaryAnnotation(key, value, type, host) {
-    if (!(this instanceof BinaryAnnotation)) {
-        return new BinaryAnnotation(key, value, type, host);
-    }
     var self = this;
 
     // TODO: validation

--- a/v2/args.js
+++ b/v2/args.js
@@ -33,9 +33,6 @@ var WriteResult = bufrw.WriteResult;
 var ReadResult = bufrw.ReadResult;
 
 function ArgRW(sizerw) {
-    if (!(this instanceof ArgRW)) {
-        return new ArgRW(sizerw);
-    }
     var self = this;
     Base.call(self);
     self.sizerw = sizerw;
@@ -66,12 +63,9 @@ ArgRW.prototype.readFrom = function readFrom(buffer, offset) {
     return self.bufrw.readFrom(buffer, offset);
 };
 
-var arg2 = ArgRW(bufrw.UInt16BE);
+var arg2 = new ArgRW(bufrw.UInt16BE);
 
 function ArgsRW(argrw) {
-    if (!(this instanceof ArgsRW)) {
-        return new ArgsRW(argrw);
-    }
     argrw = argrw || arg2;
     assert(argrw.sizerw && argrw.sizerw.width, 'invalid argrw');
     var self = this;

--- a/v2/call.js
+++ b/v2/call.js
@@ -29,7 +29,7 @@ var header = require('./header');
 var Tracing = require('./tracing');
 var Frame = require('./frame');
 var CallFlags = require('./call_flags');
-var argsrw = ArgsRW();
+var argsrw = new ArgsRW();
 
 var ResponseCodes = {
     OK: 0x00,

--- a/v2/cont.js
+++ b/v2/cont.js
@@ -25,7 +25,7 @@ var Checksum = require('./checksum');
 var ArgsRW = require('./args');
 var Frame = require('./frame');
 var CallFlags = require('./call_flags');
-var argsrw = ArgsRW();
+var argsrw = new ArgsRW();
 
 // flags:1 csumtype:1 (csum:4){0,1} (arg~2)+
 function CallRequestCont(flags, csum, args) {

--- a/v2/handler.js
+++ b/v2/handler.js
@@ -51,9 +51,6 @@ var GLOBAL_WRITE_BUFFER = new Buffer(v2.Frame.MaxSize);
 module.exports = TChannelV2Handler;
 
 function TChannelV2Handler(options) {
-    if (!(this instanceof TChannelV2Handler)) {
-        return new TChannelV2Handler(options);
-    }
     var self = this;
     EventEmitter.call(self);
     self.errorEvent = self.defineEvent('error');

--- a/v2/header.js
+++ b/v2/header.js
@@ -29,9 +29,6 @@ var errors = require('../errors');
 // allow for more precise error reporting.
 
 function HeaderRW(countrw, keyrw, valrw, options) {
-    if (!(this instanceof HeaderRW)) {
-        return new HeaderRW(countrw, keyrw, valrw, options);
-    }
     var self = this;
     self.countrw = countrw;
     self.keyrw = keyrw;
@@ -251,13 +248,13 @@ HeaderRW.prototype.lazySkip = function lazySkip(frame, offset) {
 module.exports = HeaderRW;
 
 // nh:1 (hk~1 hv~1){nh}
-module.exports.header1 = HeaderRW(bufrw.UInt8, bufrw.str1, bufrw.str1, {
+module.exports.header1 = new HeaderRW(bufrw.UInt8, bufrw.str1, bufrw.str1, {
     maxHeaderCount: 128,
     maxKeyLength: 16
 });
 
 // nh:2 (hk~2 hv~2){nh}
-module.exports.header2 = HeaderRW(bufrw.UInt16BE, bufrw.str2, bufrw.str2, {
+module.exports.header2 = new HeaderRW(bufrw.UInt16BE, bufrw.str2, bufrw.str2, {
     maxHeaderCount: Infinity,
     maxKeyLength: Infinity
 });


### PR DESCRIPTION
- ArgStream
- BatchStatsd
- InArgStream
- OutArgStream
- StreamArg
- TChannel(Self)Peer
- TChannelSelfConnection
- TChannelV2Handler
- TChannel{Root,Sub}Peers
- v2/ArgsRW
- v2/HeaderRW
- all tracing classes in trace/{agent,span}.js

r @raynos @kriskowal 