### PR TITLE
add an inspect method to channel

### DIFF
--- a/channel.js
+++ b/channel.js
@@ -46,6 +46,7 @@ var globalRandom = Math.random;
 var net = require('net');
 var format = require('util').format;
 var inherits = require('util').inherits;
+var inspect = require('util').inspect;
 
 var HostPort = require('./host-port.js');
 var nullLogger = require('./null-logger.js');
@@ -281,6 +282,12 @@ function setMaximumRelayTTL(value) {
 
         subChan.maximumRelayTTL = value;
     }
+};
+
+TChannel.prototype.inspect =
+function tchannelInspect() {
+    var self = this;
+    return 'TChannel(' + inspect(self.extendLogInfo({})) + ')';
 };
 
 TChannel.prototype.setPreferConnectionDirection =

--- a/channel.js
+++ b/channel.js
@@ -284,6 +284,15 @@ function setMaximumRelayTTL(value) {
     }
 };
 
+TChannel.prototype.toString =
+function channelToString() {
+    var self = this;
+    if (!self.topChannel) {
+        return 'TChannel(' + self.hostPort + ')';
+    }
+    return 'TSubChannel(' + self.serviceName + ',' + self.hostPort + ')';
+};
+
 TChannel.prototype.inspect =
 function tchannelInspect() {
     var self = this;


### PR DESCRIPTION
I accidentally evaluated `tchannel` in a REPL.

It spend 60 seconds printing the 200MB object with all
the peers & connections.

I added an inspect method to avoid accidentally evaluating
really really expensive objects.

r: @jcorbin @kriskowal