### PR TITLE
add methods to v2/lazy_frame that do caching

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,5 +1,8 @@
 {
     "extends": ["perf-standard"],
+    "globals": {
+        "global": false
+    },
     "rules": {
         "max-params": [2, 5],
         "max-len": [0],

--- a/benchmarks/micro/lazy-headers-perf.js
+++ b/benchmarks/micro/lazy-headers-perf.js
@@ -1,0 +1,80 @@
+// Copyright (c) 2015 Uber Technologies, Inc.
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the 'Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+'use strict';
+
+var Buffer = require('buffer').Buffer;
+var bufrw = require('bufrw');
+
+var v2 = require('../../v2/index.js');
+
+var spanId = [0, 1];
+var parentId = [2, 3];
+var traceId = [4, 5];
+var tracing = new v2.Tracing(
+    spanId, parentId, traceId
+);
+
+var frame = new v2.Frame(24,    // frame id
+    new v2.CallRequest(
+        42,                     // flags
+        99,                     // ttl
+        tracing,                // tracing
+        'castle',               // service
+        {                       // headers
+            'cn': 'mario',      // headers.cn
+            'as': 'plumber'     // headers.as
+        },                      //
+        v2.Checksum.Types.None, // csum
+        ['door', 'key', 'turn'] // args
+    )
+);
+var CN_BUFFER = new Buffer('cn');
+var ITERATIONS = 1000 * 1000 * 10;
+
+function main() {
+    var buf = bufrw.toBuffer(v2.Frame.RW, frame);
+
+    var lazyFrame = bufrw.fromBuffer(v2.LazyFrame.RW, buf);
+
+    var res = lazyFrame.bodyRW.lazy.readHeaders(lazyFrame);
+    var headers = res.value;
+
+    runLoop(headers, 1000);
+    console.log('done warmup');
+    setTimeout(pastWarmup, 5000);
+
+    function pastWarmup() {
+        console.log('running bench');
+        runLoop(headers, ITERATIONS);
+    }
+}
+
+function runLoop(headers, ITER) {
+    var resArr = new Array(10);
+
+    for (var i = 0; i < ITER; i++) {
+        resArr[i % 10] = headers.getValue(CN_BUFFER);
+    }
+}
+
+if (require.main === module) {
+    main();
+}

--- a/benchmarks/micro/lazy-headers-perf.js
+++ b/benchmarks/micro/lazy-headers-perf.js
@@ -1,4 +1,24 @@
 // Copyright (c) 2015 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+// Copyright (c) 2015 Uber Technologies, Inc.
 
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the 'Software"), to deal
@@ -22,7 +42,10 @@
 
 var Buffer = require('buffer').Buffer;
 var bufrw = require('bufrw');
+var setTimeout = require('timers').setTimeout;
+var console = require('console');
 
+/*eslint no-console: 0*/
 var v2 = require('../../v2/index.js');
 
 var spanId = [0, 1];

--- a/benchmarks/micro/lazy-headers-perf.js
+++ b/benchmarks/micro/lazy-headers-perf.js
@@ -18,26 +18,6 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-// Copyright (c) 2015 Uber Technologies, Inc.
-
-// Permission is hereby granted, free of charge, to any person obtaining a copy
-// of this software and associated documentation files (the 'Software"), to deal
-// in the Software without restriction, including without limitation the rights
-// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-// copies of the Software, and to permit persons to whom the Software is
-// furnished to do so, subject to the following conditions:
-//
-// The above copyright notice and this permission notice shall be included in
-// all copies or substantial portions of the Software.
-//
-// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-// THE SOFTWARE.
-
 'use strict';
 
 var Buffer = require('buffer').Buffer;

--- a/benchmarks/micro/reading-important-fields.js
+++ b/benchmarks/micro/reading-important-fields.js
@@ -1,0 +1,118 @@
+// Copyright (c) 2015 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+// Copyright (c) 2015 Uber Technologies, Inc.
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the 'Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+'use strict';
+
+var Buffer = require('buffer').Buffer;
+var bufrw = require('bufrw');
+var setTimeout = require('timers').setTimeout;
+var console = require('console');
+
+/*eslint no-console: 0*/
+var v2 = require('../../v2/index.js');
+
+var spanId = [0, 1];
+var parentId = [2, 3];
+var traceId = [4, 5];
+var tracing = new v2.Tracing(
+    spanId, parentId, traceId
+);
+
+var frame = new v2.Frame(24,    // frame id
+    new v2.CallRequest(
+        42,                     // flags
+        99,                     // ttl
+        tracing,                // tracing
+        'castle',               // service
+        {                       // headers
+            'cn': 'mario',      // headers.cn
+            'as': 'plumber'     // headers.as
+        },                      //
+        v2.Checksum.Types.None, // csum
+        ['door', 'key', 'turn'] // args
+    )
+);
+
+function main(ITER) {
+    var buf = bufrw.toBuffer(v2.Frame.RW, frame);
+
+    runLoop(buf, 1000);
+    console.log('done warmup');
+    setTimeout(pastWarmup, 250);
+
+    function pastWarmup() {
+        console.log('running bench', process.pid);
+        var start = Date.now();
+        runLoop(buf, ITER);
+        var end = Date.now();
+        console.log('finised bench', end - start);
+    }
+}
+
+function runLoop(buf, ITER) {
+    var resArr = new Array(10);
+
+    for (var i = 0; i < ITER; i++) {
+        var lazyFrame = bufrw.fromBuffer(v2.LazyFrame.RW, buf);
+        var serviceName = lazyFrame.bodyRW.lazy.readServiceStr(lazyFrame);
+        var callerName = lazyFrame.bodyRW.lazy.readCallerNameStr(lazyFrame);
+        var endpoint = lazyFrame.bodyRW.lazy.readArg1Str(lazyFrame);
+
+        resArr[i % 10] = new FrameData(
+            serviceName, callerName, endpoint
+        );
+    }
+}
+
+function FrameData(serviceName, callerName, endpoint) {
+    this.serviceName = serviceName;
+    this.callerName = callerName;
+    this.endpoint = endpoint;
+}
+
+if (require.main === module) {
+    var arg = process.argv[2];
+    var ITERATIONS = 1000 * 1000 * 10;
+    if (arg) {
+        ITERATIONS = 1000 * 1000 * parseInt(arg, 10);
+    }
+
+    main(ITERATIONS);
+}

--- a/benchmarks/micro/reading-important-fields.js
+++ b/benchmarks/micro/reading-important-fields.js
@@ -40,7 +40,7 @@
 
 'use strict';
 
-var Buffer = require('buffer').Buffer;
+var process = global.process;
 var bufrw = require('bufrw');
 var setTimeout = require('timers').setTimeout;
 var console = require('console');

--- a/benchmarks/micro/reading-important-fields.js
+++ b/benchmarks/micro/reading-important-fields.js
@@ -18,26 +18,6 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-// Copyright (c) 2015 Uber Technologies, Inc.
-
-// Permission is hereby granted, free of charge, to any person obtaining a copy
-// of this software and associated documentation files (the 'Software"), to deal
-// in the Software without restriction, including without limitation the rights
-// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-// copies of the Software, and to permit persons to whom the Software is
-// furnished to do so, subject to the following conditions:
-//
-// The above copyright notice and this permission notice shall be included in
-// all copies or substantial portions of the Software.
-//
-// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-// THE SOFTWARE.
-
 'use strict';
 
 var process = global.process;

--- a/test/v2/lazy_frame.js
+++ b/test/v2/lazy_frame.js
@@ -187,23 +187,24 @@ test('CallRequest.lazy cache', function t(assert) {
     assert.equal(counters.toString, 1,
         'should not call toString() in second readService()');
 
-    var endpoint1 = lazyFrame.bodyRW.lazy.readArg1str(lazyFrame);
+
+    var endpoint1 = lazyFrame.bodyRW.lazy.readArg1Str(lazyFrame);
 
     assert.equal(endpoint1.value, 'door',
         'expected endpoint to be door');
     assert.equal(counters.slice, 1,
-        'should not call slice() in readArg1str()');
+        'should not call slice() in readArg1Str()');
     assert.equal(counters.toString, 2,
-        'should call toString() in readArg1str()');
+        'should call toString() in readArg1Str()');
 
-    var endpoint2 = lazyFrame.bodyRW.lazy.readArg1str(lazyFrame);
+    var endpoint2 = lazyFrame.bodyRW.lazy.readArg1Str(lazyFrame);
 
     assert.equal(endpoint2.value, 'door',
         'expected endpoint to be door');
     assert.equal(counters.slice, 1,
-        'should not call slice() in second readArg1str()');
+        'should not call slice() in second readArg1Str()');
     assert.equal(counters.toString, 2,
-        'should not call toString() in second readArg1str()');
+        'should not call toString() in second readArg1Str()');
 
     var callerName1 = lazyFrame.bodyRW.lazy.readCallerName(lazyFrame);
 

--- a/v2/args.js
+++ b/v2/args.js
@@ -62,6 +62,10 @@ ArgRW.prototype.readFrom = function readFrom(buffer, offset) {
     return this.bufrw.readFrom(buffer, offset);
 };
 
+ArgRW.prototype.readFromstr = function readFromstr(buffer, offset) {
+    return this.strrw.readFrom(buffer, offset);
+};
+
 var arg2 = new ArgRW(bufrw.UInt16BE);
 
 function ArgsRW(argrw) {

--- a/v2/args.js
+++ b/v2/args.js
@@ -62,10 +62,6 @@ ArgRW.prototype.readFrom = function readFrom(buffer, offset) {
     return this.bufrw.readFrom(buffer, offset);
 };
 
-ArgRW.prototype.readFromstr = function readFromstr(buffer, offset) {
-    return this.strrw.readFrom(buffer, offset);
-};
-
 var arg2 = new ArgRW(bufrw.UInt16BE);
 
 function ArgsRW(argrw) {

--- a/v2/call.js
+++ b/v2/call.js
@@ -122,7 +122,7 @@ CallRequest.RW.lazy.readTracing = function lazyReadTracing(frame) {
 
 CallRequest.RW.lazy.serviceOffset = CallRequest.RW.lazy.tracingOffset + 25;
 CallRequest.RW.lazy.readService = function lazyReadService(frame) {
-    if (frame.cache.serviceRes) {
+    if (frame.cache.serviceRes !== null) {
         return frame.cache.serviceRes;
     }
     // service~1
@@ -136,7 +136,7 @@ CallRequest.RW.lazy.readService = function lazyReadService(frame) {
 };
 
 CallRequest.RW.lazy.readServiceStr = function lazyReadServiceStr(frame) {
-    if (frame.cache.serviceStr) {
+    if (frame.cache.serviceStr !== null) {
         return frame.cache.serviceStr;
     }
 
@@ -167,7 +167,7 @@ CallRequest.RW.lazy.readHeaders = function readHeaders(frame) {
     // last fixed offset
     var offset = CallRequest.RW.lazy.serviceOffset;
 
-    if (frame.cache.headerStartOffset) {
+    if (frame.cache.headerStartOffset !== null) {
         offset = frame.cache.headerStartOffset;
     } else {
         // SKIP service~1
@@ -189,13 +189,13 @@ CallRequest.RW.lazy.readHeaders = function readHeaders(frame) {
 CallRequest.RW.lazy.readCallerNameStr =
 function readCallerNameStr(frame) {
     /*eslint complexity: [2, 20]*/
-    if (frame.cache.callerNameStr) {
+    if (frame.cache.callerNameStr !== null) {
         return frame.cache.callerNameStr;
     }
 
     var offset = null;
 
-    if (frame.cache.headerStartOffset) {
+    if (frame.cache.headerStartOffset !== null) {
         offset = frame.cache.headerStartOffset;
     } else {
         offset = CallRequest.RW.lazy.serviceOffset;
@@ -294,7 +294,7 @@ CallRequest.RW.lazy.readArg1 = function readArg1(frame) {
 };
 
 CallRequest.RW.lazy.readArg1Str = function readArg1Str(frame) {
-    if (frame.cache.arg1Str) {
+    if (frame.cache.arg1Str !== null) {
         return frame.cache.arg1Str;
     }
 
@@ -340,7 +340,7 @@ function getHeadersOffset(frame) {
     var res = null;
     var offset = 0;
 
-    if (frame.cache.csumStartOffset) {
+    if (frame.cache.csumStartOffset !== null) {
         offset = frame.cache.csumStartOffset;
     } else {
         // last fixed offset

--- a/v2/call.js
+++ b/v2/call.js
@@ -167,7 +167,7 @@ CallRequest.RW.lazy.readArg1 = function readArg1(frame, headers) {
     return argsrw.argrw.readFrom(frame.buffer, offset);
 };
 
-CallRequest.RW.lazy.readArg1str = function readArg1str(frame, headers) {
+CallRequest.RW.lazy.readArg1Str = function readArg1Str(frame, headers) {
     if (frame.cache.arg1Str) {
         return frame.cache.arg1Str;
     }
@@ -188,7 +188,7 @@ CallRequest.RW.lazy.readArg1str = function readArg1str(frame, headers) {
     offset = res.offset;
 
     // READ arg~2
-    res = argsrw.argrw.readFromstr(frame.buffer, offset);
+    res = argsrw.argrw.strrw.readFrom(frame.buffer, offset);
 
     frame.cache.arg1Str = res;
 

--- a/v2/call.js
+++ b/v2/call.js
@@ -98,18 +98,42 @@ CallRequest.RW.lazy.readTracing = function lazyReadTracing(frame) {
 
 CallRequest.RW.lazy.serviceOffset = CallRequest.RW.lazy.tracingOffset + 25;
 CallRequest.RW.lazy.readService = function lazyReadService(frame) {
-    if (frame.cache.serviceStr) {
-        return frame.cache.serviceStr;
+    if (frame.cache.serviceRes) {
+        return frame.cache.serviceRes;
     }
-
     // service~1
     var res = bufrw.str1.readFrom(
         frame.buffer, CallRequest.RW.lazy.serviceOffset
     );
-    frame.cache.serviceStr = res;
+    frame.cache.serviceRes = res;
     frame.cache.headerStartOffset = res.offset;
 
     return res;
+};
+
+CallRequest.RW.lazy.readServiceStr = function lazyReadServiceStr(frame) {
+    if (frame.cache.serviceStr) {
+        return frame.cache.serviceStr;
+    }
+
+    var strLength = frame.buffer.readUInt8(
+        CallRequest.RW.lazy.serviceOffset, false
+    );
+    var end = CallRequest.RW.lazy.serviceOffset + 1 + strLength;
+    if (frame.size < end) {
+        return null;
+    }
+
+    var serviceNameStr = frame.buffer.toString(
+        'utf8',
+        CallRequest.RW.lazy.serviceOffset + 1,
+        end
+    );
+
+    frame.cache.serviceStr = serviceNameStr;
+    frame.cache.headerStartOffset = end;
+
+    return serviceNameStr;
 };
 
 CallRequest.RW.lazy.readHeaders = function readHeaders(frame) {

--- a/v2/call.js
+++ b/v2/call.js
@@ -45,8 +45,13 @@ var ResponseCodes = {
     Error: 0x01
 };
 
-var fastBufferToString = process.version === 'v0.10.32' ?
-    node10ToString : allNodeToString;
+var NODE_VERSION = process.versions.node;
+var NODE_VERSION_PARTS = NODE_VERSION.split('.');
+
+var fastBufferToString = allNodeToString;
+if (NODE_VERSION_PARTS[1] === '10' && NODE_VERSION_PARTS[2] >= '32') {
+    fastBufferToString = node10ToString;
+}
 
 function node10ToString(fastBuf, start, end) {
     var slowBuf = fastBuf.parent;

--- a/v2/call.js
+++ b/v2/call.js
@@ -181,24 +181,6 @@ CallRequest.RW.lazy.readHeaders = function readHeaders(frame) {
     return res;
 };
 
-CallRequest.RW.lazy.readCallerName = function readCallerName(frame) {
-    if (frame.cache.callerNameStr) {
-        return frame.cache.callerNameStr;
-    }
-
-    var res = CallRequest.RW.lazy.readHeaders(frame);
-    if (res.err) {
-        return res;
-    }
-
-    var callerName = res.value.getStringValue(CN_BUFFER);
-    res = bufrw.ReadResult.just(res.offset, callerName);
-
-    frame.cache.callerNameStr = res;
-
-    return res;
-};
-
 CallRequest.RW.lazy.readCallerNameStr =
 function readCallerNameStr(frame) {
     /*eslint complexity: [2, 20]*/

--- a/v2/call.js
+++ b/v2/call.js
@@ -278,9 +278,7 @@ function readCallerNameStr(frame) {
     }
 
     var callerNameStr = fastBufferToString(
-        frame.buffer,
-        CallRequest.RW.lazy.serviceOffset + 1,
-        end
+        frame.buffer, offset, end
     );
 
     frame.cache.callerNameStr = callerNameStr;

--- a/v2/header.js
+++ b/v2/header.js
@@ -257,7 +257,7 @@ module.exports.header2 = new HeaderRW(bufrw.UInt16BE, bufrw.str2, bufrw.str2, {
 function KeyVals(buffer, length) {
     this.length = length;
     this.buffer = buffer;
-    this.data = new Uint16Array(this.length * 4);
+    this.data = new Array(this.length * 4);
     this.index = 0;
     this.offset = 0;
 }

--- a/v2/lazy_frame.js
+++ b/v2/lazy_frame.js
@@ -46,6 +46,9 @@ function CallRequestCache() {
     this.serviceStr = null;
     this.callerNameStr = null;
     this.arg1Str = null;
+
+    this.headerStartOffset = null;
+    this.csumStartOffset = null;
 }
 
 // size:2 type:1 reserved:1 id:4 reserved:8 ...

--- a/v2/lazy_frame.js
+++ b/v2/lazy_frame.js
@@ -43,9 +43,11 @@ function LazyFrame(size, type, id, buffer) {
 }
 
 function CallRequestCache() {
-    this.serviceStr = null;
+    this.serviceRes = null;
     this.callerNameStr = null;
     this.arg1Str = null;
+
+    this.serviceStr = null;
 
     this.headerStartOffset = null;
     this.csumStartOffset = null;

--- a/v2/lazy_frame.js
+++ b/v2/lazy_frame.js
@@ -38,6 +38,14 @@ function LazyFrame(size, type, id, buffer) {
 
     this.body = null;
     this.bodyRW = null;
+    this.circuit = null;
+    this.cache = new CallRequestCache();
+}
+
+function CallRequestCache() {
+    this.serviceStr = null;
+    this.callerNameStr = null;
+    this.arg1Str = null;
 }
 
 // size:2 type:1 reserved:1 id:4 reserved:8 ...


### PR DESCRIPTION
Most of these changes are straight forward and
should improve perf.

The change to the header parsing hot code might
reduce perf.. not really sure, need more full
benchmarks.

I tried to microbench my change to header parsing
to make sure the new method still get's inlined.

I got:

```
raynos at raynos-ThinkPad-T440p  ~/uber/tchannel-node on lazy-caching*
$ cat inline | grep 'findOffset called'
Inlined findOffset called from getValue.
Inlined findOffset called from getValue.
Inlined findOffset called from getValue.
Inlined findOffset called from getValue.
Inlined findOffset called from getValue.
Inlined findOffset called from getValue.
Inlined findOffset called from getValue.
Inlined findOffset called from getValue.
Inlined findOffset called from getValue.
Inlined findOffset called from getValue.
Inlined findOffset called from getValue.
Did not inline findOffset called from getValue (target not inlineable).
```

Not sure why it bailed the inline out...

r: @jcorbin @rf