### PR TITLE
perf: use array instead of typed array

### DIFF
--- a/v2/header.js
+++ b/v2/header.js
@@ -257,7 +257,7 @@ module.exports.header2 = new HeaderRW(bufrw.UInt16BE, bufrw.str2, bufrw.str2, {
 function KeyVals(buffer, length) {
     this.length = length;
     this.buffer = buffer;
-    this.data = new Uint16Array(this.length * 4);
+    this.data = new Array(this.length * 4);
     this.index = 0;
     this.offset = 0;
 }


### PR DESCRIPTION
It turns out that typed arrays are not optimized.
This makes the code faster.

r: @jcorbin @rf