### PR TITLE
perf: Implement only readServiceStr()

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,5 +1,8 @@
 {
     "extends": ["perf-standard"],
+    "globals": {
+        "global": false
+    },
     "rules": {
         "max-params": [2, 5],
         "max-len": [0],

--- a/benchmarks/micro/reading-important-fields.js
+++ b/benchmarks/micro/reading-important-fields.js
@@ -1,0 +1,118 @@
+// Copyright (c) 2015 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+// Copyright (c) 2015 Uber Technologies, Inc.
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the 'Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+'use strict';
+
+var Buffer = require('buffer').Buffer;
+var bufrw = require('bufrw');
+var setTimeout = require('timers').setTimeout;
+var console = require('console');
+
+/*eslint no-console: 0*/
+var v2 = require('../../v2/index.js');
+
+var spanId = [0, 1];
+var parentId = [2, 3];
+var traceId = [4, 5];
+var tracing = new v2.Tracing(
+    spanId, parentId, traceId
+);
+
+var frame = new v2.Frame(24,    // frame id
+    new v2.CallRequest(
+        42,                     // flags
+        99,                     // ttl
+        tracing,                // tracing
+        'castle',               // service
+        {                       // headers
+            'cn': 'mario',      // headers.cn
+            'as': 'plumber'     // headers.as
+        },                      //
+        v2.Checksum.Types.None, // csum
+        ['door', 'key', 'turn'] // args
+    )
+);
+
+function main(ITER) {
+    var buf = bufrw.toBuffer(v2.Frame.RW, frame);
+
+    runLoop(buf, 1000);
+    console.log('done warmup');
+    setTimeout(pastWarmup, 250);
+
+    function pastWarmup() {
+        console.log('running bench', process.pid);
+        var start = Date.now();
+        runLoop(buf, ITER);
+        var end = Date.now();
+        console.log('finised bench', end - start);
+    }
+}
+
+function runLoop(buf, ITER) {
+    var resArr = new Array(10);
+
+    for (var i = 0; i < ITER; i++) {
+        var lazyFrame = bufrw.fromBuffer(v2.LazyFrame.RW, buf);
+        var serviceName = lazyFrame.bodyRW.lazy.readServiceStr(lazyFrame);
+        var callerName = lazyFrame.bodyRW.lazy.readCallerNameStr(lazyFrame);
+        var endpoint = lazyFrame.bodyRW.lazy.readArg1Str(lazyFrame);
+
+        resArr[i % 10] = new FrameData(
+            serviceName, callerName, endpoint
+        );
+    }
+}
+
+function FrameData(serviceName, callerName, endpoint) {
+    this.serviceName = serviceName;
+    this.callerName = callerName;
+    this.endpoint = endpoint;
+}
+
+if (require.main === module) {
+    var arg = process.argv[2];
+    var ITERATIONS = 1000 * 1000 * 10;
+    if (arg) {
+        ITERATIONS = 1000 * 1000 * parseInt(arg, 10);
+    }
+
+    main(ITERATIONS);
+}

--- a/benchmarks/micro/reading-service-name-str.js
+++ b/benchmarks/micro/reading-service-name-str.js
@@ -18,26 +18,6 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-// Copyright (c) 2015 Uber Technologies, Inc.
-
-// Permission is hereby granted, free of charge, to any person obtaining a copy
-// of this software and associated documentation files (the 'Software"), to deal
-// in the Software without restriction, including without limitation the rights
-// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-// copies of the Software, and to permit persons to whom the Software is
-// furnished to do so, subject to the following conditions:
-//
-// The above copyright notice and this permission notice shall be included in
-// all copies or substantial portions of the Software.
-//
-// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-// THE SOFTWARE.
-
 'use strict';
 
 var Buffer = require('buffer').Buffer;
@@ -70,49 +50,65 @@ var frame = new v2.Frame(24,    // frame id
     )
 );
 
-function main(ITER) {
+function main(mode, ITER) {
     var buf = bufrw.toBuffer(v2.Frame.RW, frame);
 
-    runLoop(buf, 1000);
+    runLoop(buf, mode, 1000);
     console.log('done warmup');
     setTimeout(pastWarmup, 250);
 
     function pastWarmup() {
         console.log('running bench', process.pid);
         var start = Date.now();
-        runLoop(buf, ITER);
+        runLoop(buf, mode, ITER);
         var end = Date.now();
         console.log('finised bench', end - start);
     }
 }
 
-function runLoop(buf, ITER) {
+function runLoop(buf, mode, ITER) {
+    if (mode === 'optimized') {
+        runOptimizedLoop(buf, ITER);
+    } else if (mode === 'default') {
+        runDefaultLoop(buf, ITER);
+    } else {
+        console.warn('noop');
+    }
+}
+
+function runDefaultLoop(buf, ITER) {
+    var resArr = new Array(10);
+
+    for (var i = 0; i < ITER; i++) {
+        var lazyFrame = bufrw.fromBuffer(v2.LazyFrame.RW, buf);
+        var res = lazyFrame.bodyRw.lazy.readService(lazyFrame);
+
+        resArr[i % 10] = new FrameData(res.value);
+    }
+}
+
+function runOptimizedLoop(buf, ITER) {
     var resArr = new Array(10);
 
     for (var i = 0; i < ITER; i++) {
         var lazyFrame = bufrw.fromBuffer(v2.LazyFrame.RW, buf);
         var serviceName = lazyFrame.bodyRW.lazy.readServiceStr(lazyFrame);
-        var callerName = lazyFrame.bodyRW.lazy.readCallerNameStr(lazyFrame);
-        var endpoint = lazyFrame.bodyRW.lazy.readArg1Str(lazyFrame);
 
-        resArr[i % 10] = new FrameData(
-            serviceName, callerName, endpoint
-        );
+        resArr[i % 10] = new FrameData(serviceName);
     }
 }
 
-function FrameData(serviceName, callerName, endpoint) {
+function FrameData(serviceName) {
     this.serviceName = serviceName;
-    this.callerName = callerName;
-    this.endpoint = endpoint;
 }
 
 if (require.main === module) {
     var arg = process.argv[2];
+    var mode = process.argv[3] || 'optimized';
     var ITERATIONS = 1000 * 1000 * 10;
     if (arg) {
         ITERATIONS = 1000 * 1000 * parseInt(arg, 10);
     }
 
-    main(ITERATIONS);
+    main(mode, ITERATIONS);
 }

--- a/test/v2/lazy_frame.js
+++ b/test/v2/lazy_frame.js
@@ -24,6 +24,7 @@ var Buffer = require('buffer').Buffer;
 var bufrw = require('bufrw');
 var test = require('tape');
 var testRW = require('bufrw/test_rw');
+var process = global.process;
 
 var TestBody = require('./lib/test_body.js');
 var v2 = require('../../v2/index.js');
@@ -38,15 +39,15 @@ var Bytes = [
 
     0x04, 0x64, 0x6f, 0x67, 0x65 // junk bytes
 ];
-var lazyFrame = new v2.LazyFrame(
+var _lazyFrame = new v2.LazyFrame(
     0x15, 0x03, 0x01,
     new Buffer(Bytes)
 );
-lazyFrame.bodyRW = v2.Frame.Types[0x03].RW;
+_lazyFrame.bodyRW = v2.Frame.Types[0x03].RW;
 
 test('LazyFrame.RW: read/write', testRW.cases(v2.LazyFrame.RW, [
     [
-        lazyFrame, Bytes
+        _lazyFrame, Bytes
     ]
 ]));
 
@@ -69,7 +70,6 @@ TestBody.testWith('LazyFrame.readFrom, invalid type', function t(assert) {
 
     assert.end();
 });
-
 
 TestBody.testWith('LazyFrame.readBody', function t(assert) {
     var frame = v2.LazyFrame.RW.readFrom(new Buffer([

--- a/v2/call.js
+++ b/v2/call.js
@@ -127,25 +127,30 @@ CallRequest.RW.lazy.readServiceStr = function lazyReadServiceStr(frame) {
         return frame.cache.serviceStr;
     }
 
-    if (frame.size < CallRequest.RW.lazy.serviceOffset + 1) {
-        return null;
+    var serviceStrEnd = null;
+    if (frame.cache.headerStartOffset) {
+        serviceStrEnd = frame.cache.headerStartOffset;
+    } else {
+        if (frame.size < CallRequest.RW.lazy.serviceOffset + 1) {
+            return null;
+        }
+        var strLength = frame.buffer.readUInt8(
+            CallRequest.RW.lazy.serviceOffset, false
+        );
+        serviceStrEnd = CallRequest.RW.lazy.serviceOffset + 1 + strLength;
+        frame.cache.headerStartOffset = serviceStrEnd;
     }
-    var strLength = frame.buffer.readUInt8(
-        CallRequest.RW.lazy.serviceOffset, false
-    );
-    var end = CallRequest.RW.lazy.serviceOffset + 1 + strLength;
 
-    if (frame.size < end) {
+    if (frame.size < serviceStrEnd) {
         return null;
     }
     var serviceNameStr = fastBufferToString(
         frame.buffer,
         CallRequest.RW.lazy.serviceOffset + 1,
-        end
+        serviceStrEnd
     );
 
     frame.cache.serviceStr = serviceNameStr;
-    frame.cache.headerStartOffset = end;
 
     return serviceNameStr;
 };

--- a/v2/call.js
+++ b/v2/call.js
@@ -168,6 +168,7 @@ CallRequest.RW.lazy.readHeaders = function readHeaders(frame) {
             return res;
         }
         offset = res.offset + res.value;
+        frame.cache.headerStartOffset = offset;
     }
 
     // READ nh:1 (hk~1 hv~1){nh}

--- a/v2/lazy_frame.js
+++ b/v2/lazy_frame.js
@@ -38,6 +38,13 @@ function LazyFrame(size, type, id, buffer) {
 
     this.body = null;
     this.bodyRW = null;
+    this.cache = new CallRequestCache();
+}
+
+function CallRequestCache() {
+    this.serviceStr = null;
+
+    this.headerStartOffset = null;
 }
 
 // size:2 type:1 reserved:1 id:4 reserved:8 ...


### PR DESCRIPTION
This is a subset of https://github.com/uber/tchannel-node/pull/271

This only implements `readServiceStr()`; I've added a benchmark
for `readServiceStr()`.

It looks like the new implementation is about 2x faster, mostly
because:

 - no allocations of `ReadResult()`
 - using `utf8Slice()` directly.

I think @rf might be working on porting this fixes back
to `bufrw` itself; this will be great.

r: @jcorbin @rf