### PR TITLE
Perf: Optimized readCallerNameStr() for lazy path

### DIFF
--- a/benchmarks/micro/reading-caller-name-str.js
+++ b/benchmarks/micro/reading-caller-name-str.js
@@ -24,6 +24,7 @@ var process = global.process;
 var bufrw = require('bufrw');
 var setTimeout = require('timers').setTimeout;
 var console = require('console');
+var Buffer = require('buffer').Buffer;
 
 /*eslint no-console: 0*/
 var v2 = require('../../v2/index.js');

--- a/benchmarks/micro/reading-caller-name-str.js
+++ b/benchmarks/micro/reading-caller-name-str.js
@@ -1,0 +1,130 @@
+// Copyright (c) 2015 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+'use strict';
+
+var process = global.process;
+var bufrw = require('bufrw');
+var setTimeout = require('timers').setTimeout;
+var console = require('console');
+
+/*eslint no-console: 0*/
+var v2 = require('../../v2/index.js');
+
+var spanId = [0, 1];
+var CN_BUFFER = new Buffer('cn');
+var parentId = [2, 3];
+var traceId = [4, 5];
+var tracing = new v2.Tracing(
+    spanId, parentId, traceId
+);
+
+var frame = new v2.Frame(24,    // frame id
+    new v2.CallRequest(
+        42,                     // flags
+        99,                     // ttl
+        tracing,                // tracing
+        'castle',               // service
+        {                       // headers
+            'cn': 'mario',      // headers.cn
+            'as': 'plumber'     // headers.as
+        },                      //
+        v2.Checksum.Types.None, // csum
+        ['door', 'key', 'turn'] // args
+    )
+);
+
+function main(mode, ITER) {
+    var buf = bufrw.toBuffer(v2.Frame.RW, frame);
+
+    runLoop(buf, mode, 1000);
+    console.log('done warmup');
+    setTimeout(pastWarmup, 250);
+
+    function pastWarmup() {
+        console.log('running bench', process.pid);
+        var start = Date.now();
+        runLoop(buf, mode, ITER);
+        var end = Date.now();
+        console.log('finised bench', end - start);
+    }
+}
+
+function runLoop(buf, mode, ITER) {
+    if (mode === 'optimized') {
+        runOptimizedLoop(buf, ITER);
+    } else if (mode === 'default') {
+        runDefaultLoop(buf, ITER);
+    } else {
+        console.warn('noop');
+    }
+}
+
+function runDefaultLoop(buf, ITER) {
+    var resArr = new Array(10);
+    var lazyFrame = bufrw.fromBuffer(v2.LazyFrame.RW, buf);
+
+    for (var i = 0; i < ITER; i++) {
+        var res = lazyFrame.bodyRW.lazy.readHeaders(lazyFrame);
+        var headers = res.value;
+
+        resArr[i % 10] = new FrameData(
+            String(headers.getValue(CN_BUFFER))
+        );
+
+        // Naughty; reset cache
+        lazyFrame.cache.callerNameStr = null;
+        lazyFrame.cache.headerStartOffset = null;
+        lazyFrame.cache.csumStartOffset = null;
+        lazyFrame.cache.cnValueOffset = null;
+    }
+}
+
+function runOptimizedLoop(buf, ITER) {
+    var resArr = new Array(10);
+    var lazyFrame = bufrw.fromBuffer(v2.LazyFrame.RW, buf);
+
+    for (var i = 0; i < ITER; i++) {
+        var callerName = lazyFrame.bodyRW.lazy.readCallerNameStr(lazyFrame);
+
+        resArr[i % 10] = new FrameData(callerName);
+
+        // Naughty; reset cache
+        lazyFrame.cache.callerNameStr = null;
+        lazyFrame.cache.headerStartOffset = null;
+        lazyFrame.cache.csumStartOffset = null;
+        lazyFrame.cache.cnValueOffset = null;
+    }
+}
+
+function FrameData(callerName) {
+    this.callerName = callerName;
+}
+
+if (require.main === module) {
+    var arg = process.argv[2];
+    var mode = process.argv[3] || 'optimized';
+    var ITERATIONS = 1000 * 1000 * 5;
+    if (arg) {
+        ITERATIONS = 1000 * 1000 * 5 * parseInt(arg, 10);
+    }
+
+    main(mode, ITERATIONS);
+}

--- a/benchmarks/micro/reading-caller-name-str.js
+++ b/benchmarks/micro/reading-caller-name-str.js
@@ -121,9 +121,9 @@ function FrameData(callerName) {
 if (require.main === module) {
     var arg = process.argv[2];
     var mode = process.argv[3] || 'optimized';
-    var ITERATIONS = 1000 * 1000 * 5;
+    var ITERATIONS = 1000 * 1000 * 2;
     if (arg) {
-        ITERATIONS = 1000 * 1000 * 5 * parseInt(arg, 10);
+        ITERATIONS = 1000 * 1000 * 2 * parseInt(arg, 10);
     }
 
     main(mode, ITERATIONS);

--- a/test/v2/lazy_frame.js
+++ b/test/v2/lazy_frame.js
@@ -196,6 +196,42 @@ test('CallRequest.lazy cache readServiceStr()', function t(assert) {
     assert.end();
 });
 
+test('CallRequest.lazy cache readCallerNameStr()', function t(assert) {
+    var buf = setupLazyFrame();
+
+    var counters = {
+        slice: 0,
+        toString: 0
+    };
+    introspectAndCountBuffer(buf, counters);
+
+    assert.equal(counters.slice, 0);
+    assert.equal(counters.toString, 0);
+    var lazyFrame = bufrw.fromBuffer(v2.LazyFrame.RW, buf);
+    assert.equal(counters.slice, 1);
+    assert.equal(counters.toString, 0);
+
+    var callerName1 = lazyFrame.bodyRW.lazy.readCallerNameStr(lazyFrame);
+
+    assert.equal(callerName1, 'mario',
+        'expected endpoint to be mario');
+    assert.equal(counters.slice, 1,
+        'should not call slice() in readCallerName()');
+    assert.equal(counters.toString, 1,
+        'should call toString() in readCallerName()');
+
+    var callerName2 = lazyFrame.bodyRW.lazy.readCallerNameStr(lazyFrame);
+
+    assert.equal(callerName2, 'mario',
+        'expected endpoint to be mario');
+    assert.equal(counters.slice, 1,
+        'should not call slice() in second readCallerName()');
+    assert.equal(counters.toString, 1,
+        'should not call toString() in second readCallerName()');
+
+    assert.end();
+});
+
 function introspectAndCountBuffer(buf, counters, wrapSlice) {
     var bufSlice = buf.slice;
     buf.slice = function proxySlice() {

--- a/test/v2/lazy_frame.js
+++ b/test/v2/lazy_frame.js
@@ -232,6 +232,33 @@ test('CallRequest.lazy cache readCallerNameStr()', function t(assert) {
     assert.end();
 });
 
+test('CallRequest.lazy cache readRoutingDelegateStr()', function t(assert) {
+    var buf = setupLazyFrame();
+
+    var counters = {
+        slice: 0,
+        toString: 0
+    };
+    introspectAndCountBuffer(buf, counters);
+
+    assert.equal(counters.slice, 0);
+    assert.equal(counters.toString, 0);
+    var lazyFrame = bufrw.fromBuffer(v2.LazyFrame.RW, buf);
+    assert.equal(counters.slice, 1);
+    assert.equal(counters.toString, 0);
+
+    var routingDelegate = lazyFrame.bodyRW.lazy.readRoutingDelegateStr(lazyFrame);
+
+    assert.equal(routingDelegate, null,
+        'expected routingDelegate to not exist');
+    assert.equal(counters.slice, 1,
+        'should not call slice() in readRoutingDelegateStr()');
+    assert.equal(counters.toString, 0,
+        'should not call toString() in readRoutingDelegateStr()');
+
+    assert.end();
+});
+
 function introspectAndCountBuffer(buf, counters, wrapSlice) {
     var bufSlice = buf.slice;
     buf.slice = function proxySlice() {

--- a/v2/call.js
+++ b/v2/call.js
@@ -134,6 +134,9 @@ CallRequest.RW.lazy.readServiceStr = function lazyReadServiceStr(frame) {
     }
 
     var headerStartOffset = findHeaderStartOffset(frame);
+    if (!headerStartOffset) {
+        return null;
+    }
 
     if (frame.size < headerStartOffset) {
         return null;
@@ -167,6 +170,9 @@ function findHeaderStartOffset(frame) {
 
 function scanAndSkipHeaders(frame) {
     var offset = findHeaderStartOffset(frame);
+    if (!offset) {
+        return false;
+    }
 
     if (frame.size < offset + 1) {
         return false;
@@ -238,6 +244,9 @@ function readCallerNameStr(frame) {
     }
 
     var offset = frame.cache.cnValueOffset;
+    if (!offset) {
+        return null;
+    }
 
     var callerNameStr = readUInt8String(frame, offset);
     if (!callerNameStr) {
@@ -263,6 +272,9 @@ function readRoutingDelegateStr(frame) {
     }
 
     var offset = frame.cache.rdValueOffset;
+    if (!offset) {
+        return null;
+    }
 
     var routingDelegateStr = readUInt8String(frame, offset);
     if (!routingDelegateStr) {

--- a/v2/call.js
+++ b/v2/call.js
@@ -37,10 +37,8 @@ var Frame = require('./frame');
 var CallFlags = require('./call_flags');
 var argsrw = new ArgsRW();
 
-var CN_BUFFER = new Buffer('cn');
-var CN_VALUE = CN_BUFFER.readUInt16BE(0, false);
-var RD_BUFFER = new Buffer('rd');
-var RD_VALUE = RD_BUFFER.readUInt16BE(0, false);
+var CN_VALUE = new Buffer('cn').readUInt16BE(0, false);
+var RD_VALUE = new Buffer('rd').readUInt16BE(0, false);
 
 var ResponseCodes = {
     OK: 0x00,

--- a/v2/call.js
+++ b/v2/call.js
@@ -172,7 +172,11 @@ CallRequest.RW.lazy.readHeaders = function readHeaders(frame) {
     }
 
     // READ nh:1 (hk~1 hv~1){nh}
-    return header.header1.lazyRead(frame, offset);
+    res = header.header1.lazyRead(frame, offset);
+
+    frame.cache.csumStartOffset = res.offset;
+
+    return res;
 };
 
 CallRequest.RW.lazy.readArg1 = function readArg1(frame, headers) {

--- a/v2/lazy_frame.js
+++ b/v2/lazy_frame.js
@@ -44,6 +44,7 @@ function LazyFrame(size, type, id, buffer) {
 function CallRequestCache() {
     this.serviceStr = null;
     this.callerNameStr = null;
+    this.routingDelegateStr = null;
 
     this.headerStartOffset = null;
     this.csumStartOffset = null;

--- a/v2/lazy_frame.js
+++ b/v2/lazy_frame.js
@@ -47,6 +47,9 @@ function CallRequestCache() {
 
     this.headerStartOffset = null;
     this.csumStartOffset = null;
+
+    this.cnValueOffset = null;
+    this.rdValueOffset = null;
 }
 
 // size:2 type:1 reserved:1 id:4 reserved:8 ...

--- a/v2/lazy_frame.js
+++ b/v2/lazy_frame.js
@@ -43,8 +43,10 @@ function LazyFrame(size, type, id, buffer) {
 
 function CallRequestCache() {
     this.serviceStr = null;
+    this.callerNameStr = null;
 
     this.headerStartOffset = null;
+    this.csumStartOffset = null;
 }
 
 // size:2 type:1 reserved:1 id:4 reserved:8 ...


### PR DESCRIPTION
This is a faster version of `readCallerNameStr()` for the lazy
path.

It's about 3x faster then the existing code.

 - Avoid creating a slice() and use toString() directly
 - Use faster toString() ( utf8Slice )
 - Avoid creating Result objects.

r: @rf @jcorbin