### PR TITLE
remember to inherit ArgRW from BufferRW

### DIFF
--- a/v2/args.js
+++ b/v2/args.js
@@ -42,6 +42,8 @@ function ArgRW(sizerw) {
     this.bufrw = bufrw.VariableBuffer(this.sizerw, true);
 }
 
+inherits(ArgRW, bufrw.Base);
+
 ArgRW.prototype.byteLength = function byteLength(arg) {
     if (typeof arg === 'string') {
         return this.strrw.byteLength(arg);


### PR DESCRIPTION
This is required for TChannel to work with the zero-alloc bufrw.

r @Raynos @jcorbin 