### PR TITLE
lazy_relay: only emit latency after flushing to socket

### DIFF
--- a/lazy_relay.js
+++ b/lazy_relay.js
@@ -376,10 +376,10 @@ LazyRelayInReq.prototype.sendErrorFrame =
 function sendErrorFrame(codeName, message) {
     var self = this;
 
+    self.conn.sendLazyErrorFrame(self.id, self.tracing, codeName, message);
+
     var now = self.channel.timers.now();
     self._observeInboundErrorFrame(now, codeName);
-
-    self.conn.sendLazyErrorFrame(self.id, self.tracing, codeName, message);
 };
 
 LazyRelayInReq.prototype.handleFrameLazily =


### PR DESCRIPTION
I made an oops. We need to write to the connection
and only then measure latency.

r: @jcorbin @rf
