### PR TITLE
Less allocations

### DIFF
--- a/service-name-handler.js
+++ b/service-name-handler.js
@@ -22,6 +22,9 @@
 
 var errors = require('./errors');
 var assert = require('assert');
+var ReadResult = require('bufrw').ReadResult;
+
+var readRes = new ReadResult();
 
 function TChannelServiceNameHandler(options) {
     if (!(this instanceof TChannelServiceNameHandler)) {
@@ -45,7 +48,7 @@ TChannelServiceNameHandler.prototype.type = 'tchannel.service-name-handler';
 TChannelServiceNameHandler.prototype.handleLazily = function handleLazily(conn, reqFrame) {
     var self = this;
 
-    var res = reqFrame.bodyRW.lazy.readService(reqFrame);
+    var res = reqFrame.bodyRW.lazy.poolReadService(readRes, reqFrame);
     if (res.err) {
         // TODO: stat?
         self.channel.logger.warn('failed to lazy read frame serviceName', conn.extendLogInfo({

--- a/test/lazy_conn_handler.js
+++ b/test/lazy_conn_handler.js
@@ -20,6 +20,8 @@
 
 'use strict';
 
+var ReadResult = require('bufrw').ReadResult;
+
 var v2 = require('../v2/index.js');
 var allocCluster = require('./lib/alloc-cluster.js');
 
@@ -45,16 +47,18 @@ allocCluster.test('connection.handler: lazy call handling', 2, function t(cluste
         conn.handler.handleCallLazily = handleCallLazily;
     }
 
+    var readRes = new ReadResult();
+
     function handleCallLazily(frame) {
         // this is conn.handler
 
-        var res = frame.bodyRW.lazy.readService(frame);
+        var res = frame.bodyRW.lazy.poolReadService(readRes, frame);
         if (res.err) {
             throw res.err;
         }
         assert.equal(res.value, 'bob', 'expected called service name');
 
-        res = frame.bodyRW.lazy.readArg1(frame);
+        res = frame.bodyRW.lazy.poolReadArg1(readRes, frame);
         if (res.err) {
             throw res.err;
         }

--- a/test/lazy_handler.js
+++ b/test/lazy_handler.js
@@ -23,6 +23,10 @@
 var v2 = require('../v2/index.js');
 var allocCluster = require('./lib/alloc-cluster.js');
 
+var ReadResult = require('bufrw').ReadResult;
+
+var readRes = new ReadResult();
+
 allocCluster.test('channel.handler: lazy call handling', 2, function t(cluster, assert) {
     var one = cluster.channels[0];
     var two = cluster.channels[1];
@@ -42,13 +46,13 @@ allocCluster.test('channel.handler: lazy call handling', 2, function t(cluster, 
     server.handler.handleLazily = handleCallLazily;
 
     function handleCallLazily(conn, frame) {
-        var res = frame.bodyRW.lazy.readService(frame);
+        var res = frame.bodyRW.lazy.poolReadService(readRes, frame);
         if (res.err) {
             throw res.err;
         }
         assert.equal(res.value, 'bob', 'expected called service name');
 
-        res = frame.bodyRW.lazy.readArg1(frame);
+        res = frame.bodyRW.lazy.poolReadArg1(readRes, frame);
         if (res.err) {
             throw res.err;
         }

--- a/test/v2/call.js
+++ b/test/v2/call.js
@@ -22,6 +22,7 @@
 
 var test = require('tape');
 var testRW = require('bufrw/test_rw');
+var Frame = require('../../v2/frame.js');
 var Call = require('../../v2/call.js');
 var Checksum = require('../../v2/checksum.js');
 var Tracing = require('../../v2/tracing.js');

--- a/test/v2/lazy_frame.js
+++ b/test/v2/lazy_frame.js
@@ -26,6 +26,11 @@ var test = require('tape');
 var testRW = require('bufrw/test_rw');
 var process = global.process;
 
+var ReadResult = require('bufrw').ReadResult;
+var WriteResult = require('bufrw').WriteResult;
+var readRes = new ReadResult();
+var writeRes = new WriteResult();
+
 var TestBody = require('./lib/test_body.js');
 var v2 = require('../../v2/index.js');
 
@@ -495,7 +500,7 @@ test('CallRequest.RW.lazy', function t(assert) {
 
     // validate call req lazy reading
     assertReadRes(
-        v2.CallRequest.RW.lazy.readFlags(lazyFrame),
+        v2.CallRequest.RW.lazy.poolReadFlags(readRes, lazyFrame),
         frame.body.flags,
         'CallRequest.RW.lazy.readFlags');
     assert.equal(
@@ -503,15 +508,15 @@ test('CallRequest.RW.lazy', function t(assert) {
         frame.body.ttl,
         'CallRequest.RW.lazy.readTTL');
     assertReadRes(
-        v2.CallRequest.RW.lazy.readTracing(lazyFrame),
+        v2.CallRequest.RW.lazy.poolReadTracing(readRes, lazyFrame),
         tracing,
         'CallRequest.RW.lazy.readTracing');
     assertReadRes(
-        v2.CallRequest.RW.lazy.readService(lazyFrame),
+        v2.CallRequest.RW.lazy.poolReadService(readRes, lazyFrame),
         frame.body.service,
         'CallRequest.RW.lazy.readService');
     assertReadRes(
-        v2.CallRequest.RW.lazy.readArg1(lazyFrame),
+        v2.CallRequest.RW.lazy.poolReadArg1(readRes, lazyFrame),
         Buffer(frame.body.args[0]),
         'CallRequest.RW.lazy.readArg1');
     assert.equal(
@@ -520,7 +525,7 @@ test('CallRequest.RW.lazy', function t(assert) {
         'CallRequest.RW.lazy.isFrameTerminal');
 
     // validate lazy header reading
-    var res = v2.CallRequest.RW.lazy.readHeaders(lazyFrame);
+    var res = v2.CallRequest.RW.lazy.poolReadHeaders(readRes, lazyFrame);
     assert.ifError(res.err, 'no error from v2.CallRequest.RW.lazy.readHeaders');
     var headers = res.value;
     if (headers) {
@@ -545,7 +550,7 @@ test('CallRequest.RW.lazy', function t(assert) {
             'expected header "as" => "plumber"');
         // readArg1 can re-use readHeaders work
         assertReadRes(
-            v2.CallRequest.RW.lazy.readArg1(lazyFrame, headers),
+            v2.CallRequest.RW.lazy.poolReadArg1(readRes, lazyFrame, headers),
             Buffer(frame.body.args[0]),
             'CallRequest.RW.lazy.readArg1, with headers');
     }
@@ -553,7 +558,7 @@ test('CallRequest.RW.lazy', function t(assert) {
     // validate call req lazy writing
     var newTTL = frame.body.ttl - 15;
     assert.ifError(
-        v2.CallRequest.RW.lazy.writeTTL(newTTL, lazyFrame).err,
+        v2.CallRequest.RW.lazy.poolWriteTTL(writeRes, newTTL, lazyFrame).err,
         'no error from v2.CallRequest.RW.lazy.writeTTL');
     var newFrame = bufrw.fromBuffer(v2.Frame.RW, lazyFrame.buffer);
     assert.equal(
@@ -600,11 +605,11 @@ test('CallResponse.RW.lazy', function t(assert) {
 
     // validate call res lazy reading
     assertReadRes(
-        v2.CallResponse.RW.lazy.readFlags(lazyFrame),
+        v2.CallResponse.RW.lazy.poolReadFlags(readRes, lazyFrame),
         frame.body.flags,
         'CallResponse.RW.lazy.readFlags');
     assertReadRes(
-        v2.CallResponse.RW.lazy.readTracing(lazyFrame),
+        v2.CallResponse.RW.lazy.poolReadTracing(readRes, lazyFrame),
         tracing,
         'CallResponse.RW.lazy.readTracing');
     assert.equal(
@@ -612,12 +617,12 @@ test('CallResponse.RW.lazy', function t(assert) {
         !(frame.body.flags & v2.CallFlags.Fragment),
         'CallResponse.RW.lazy.isFrameTerminal');
     assertReadRes(
-        v2.CallResponse.RW.lazy.readArg1(lazyFrame),
+        v2.CallResponse.RW.lazy.poolReadArg1(readRes, lazyFrame),
         Buffer(frame.body.args[0]),
         'CallResponse.RW.lazy.readArg1');
 
     // validate lazy header reading
-    var res = v2.CallResponse.RW.lazy.readHeaders(lazyFrame);
+    var res = v2.CallResponse.RW.lazy.poolReadHeaders(readRes, lazyFrame);
     assert.ifError(res.err, 'no error from v2.CallResponse.RW.lazy.readHeaders');
     var headers = res.value;
     if (headers) {
@@ -638,7 +643,7 @@ test('CallResponse.RW.lazy', function t(assert) {
             'expected header "as" => "plumber"');
         // readArg1 can re-use readHeaders work
         assertReadRes(
-            v2.CallResponse.RW.lazy.readArg1(lazyFrame, headers),
+            v2.CallResponse.RW.lazy.poolReadArg1(readRes, lazyFrame, headers),
             Buffer(frame.body.args[0]),
             'CallResponse.RW.lazy.readArg1, with headers');
     }

--- a/v2/call.js
+++ b/v2/call.js
@@ -614,9 +614,9 @@ CallResponse.RW = bufrw.Base(callResLength, readCallResFrom, writeCallResInto, t
 CallResponse.RW.lazy = {};
 
 CallResponse.RW.lazy.flagsOffset = Frame.Overhead;
-CallResponse.RW.lazy.readFlags = function readFlags(destResult, frame) {
+CallResponse.RW.lazy.readFlags = function readFlags(frame) {
     // flags:1
-    return bufrw.UInt8.poolReadFrom(destResult, frame.buffer, CallResponse.RW.lazy.flagsOffset);
+    return bufrw.UInt8.readFrom(frame.buffer, CallResponse.RW.lazy.flagsOffset);
 };
 
 CallResponse.RW.lazy.codeOffset = CallResponse.RW.lazy.flagsOffset + 1;

--- a/v2/checksum.js
+++ b/v2/checksum.js
@@ -107,8 +107,8 @@ Checksum.RW = bufrw.Switch(bufrw.UInt8, rwCases, {
     dataKey: 'val'
 });
 
-Checksum.RW.lazySkip = function lazySkip(frame, offset) {
-    var res = bufrw.UInt8.readFrom(frame.buffer, offset);
+Checksum.RW.poolLazySkip = function poolLazySkip(destResult, frame, offset) {
+    var res = bufrw.UInt8.poolReadFrom(destResult, frame.buffer, offset);
     if (res.err) {
         return res;
     }

--- a/v2/cont.js
+++ b/v2/cont.js
@@ -40,7 +40,7 @@ function CallRequestCont(flags, csum, args) {
 
 CallRequestCont.TypeCode = 0x13;
 CallRequestCont.Cont = CallRequestCont;
-CallRequestCont.RW = bufrw.Base(callReqContLength, readCallReqContFrom, writeCallReqContInto);
+CallRequestCont.RW = bufrw.Base(callReqContLength, readCallReqContFrom, writeCallReqContInto, true);
 
 CallRequestCont.RW.lazy = {};
 
@@ -56,7 +56,7 @@ CallRequestCont.RW.lazy.isFrameTerminal = function isFrameTerminal(frame) {
     return !frag;
 };
 
-function callReqContLength(body) {
+function callReqContLength(destResult, body) {
     var res;
     var length = 0;
 
@@ -64,30 +64,31 @@ function callReqContLength(body) {
     length += bufrw.UInt8.width;
 
     // csumtype:1 (csum:4){0,1} (arg~2)*
-    res = argsrw.byteLength(body);
+    res = argsrw.poolByteLength(destResult, body);
     if (!res.err) res.length += length;
 
     return res;
 }
 
-function readCallReqContFrom(buffer, offset) {
+function readCallReqContFrom(destResult, buffer, offset) {
     var res;
+    // TODO: allow these to be pooled
     var body = new CallRequestCont();
 
     // flags:1
-    res = bufrw.UInt8.readFrom(buffer, offset);
+    res = bufrw.UInt8.poolReadFrom(destResult, buffer, offset);
     if (res.err) return res;
     offset = res.offset;
     body.flags = res.value;
 
     // csumtype:1 (csum:4){0,1} (arg~2)*
-    res = argsrw.readFrom(body, buffer, offset);
+    res = argsrw.poolReadFrom(destResult, body, buffer, offset);
     if (!res.err) res.value = body;
 
     return res;
 }
 
-function writeCallReqContInto(body, buffer, offset) {
+function writeCallReqContInto(destResult, body, buffer, offset) {
     var start = offset;
     var res;
 
@@ -95,12 +96,12 @@ function writeCallReqContInto(body, buffer, offset) {
     offset += bufrw.UInt8.width;
 
     // csumtype:1 (csum:4){0,1} (arg~2)* -- (may mutate body.flags)
-    res = argsrw.writeInto(body, buffer, offset);
+    res = argsrw.poolWriteInto(destResult, body, buffer, offset);
     if (res.err) return res;
     offset = res.offset;
 
     // now we know the final flags, write them
-    res = bufrw.UInt8.writeInto(body.flags, buffer, start);
+    res = bufrw.UInt8.poolWriteInto(destResult, body.flags, buffer, start);
     if (!res.err) res.offset = offset;
 
     return res;
@@ -121,7 +122,7 @@ function CallResponseCont(flags, csum, args) {
 
 CallResponseCont.TypeCode = 0x14;
 CallResponseCont.Cont = CallResponseCont;
-CallResponseCont.RW = bufrw.Base(callResContLength, readCallResContFrom, writeCallResContInto);
+CallResponseCont.RW = bufrw.Base(callResContLength, readCallResContFrom, writeCallResContInto, true);
 
 CallResponseCont.RW.lazy = {};
 
@@ -137,7 +138,7 @@ CallResponseCont.RW.lazy.isFrameTerminal = function isFrameTerminal(frame) {
     return !frag;
 };
 
-function callResContLength(body) {
+function callResContLength(destResult, body) {
     var res;
     var length = 0;
 
@@ -145,30 +146,30 @@ function callResContLength(body) {
     length += bufrw.UInt8.width;
 
     // csumtype:1 (csum:4){0,1} (arg~2)*
-    res = argsrw.byteLength(body);
+    res = argsrw.poolByteLength(destResult, body);
     if (!res.err) res.length += length;
 
     return res;
 }
 
-function readCallResContFrom(buffer, offset) {
+function readCallResContFrom(destResult, buffer, offset) {
     var res;
     var body = new CallResponseCont();
 
     // flags:1
-    res = bufrw.UInt8.readFrom(buffer, offset);
+    res = bufrw.UInt8.poolReadFrom(destResult, buffer, offset);
     if (res.err) return res;
     offset = res.offset;
     body.flags = res.value;
 
     // csumtype:1 (csum:4){0,1} (arg~2)*
-    res = argsrw.readFrom(body, buffer, offset);
+    res = argsrw.poolReadFrom(destResult, body, buffer, offset);
     if (!res.err) res.value = body;
 
     return res;
 }
 
-function writeCallResContInto(body, buffer, offset) {
+function writeCallResContInto(destResult, body, buffer, offset) {
     var start = offset;
     var res;
 
@@ -176,12 +177,12 @@ function writeCallResContInto(body, buffer, offset) {
     offset += bufrw.UInt8.width;
 
     // csumtype:1 (csum:4){0,1} (arg~2)* -- (may mutate body.flags)
-    res = argsrw.writeInto(body, buffer, offset);
+    res = argsrw.poolWriteInto(destResult, body, buffer, offset);
     if (res.err) return res;
     offset = res.offset;
 
     // now we know the final flags, write them
-    res = bufrw.UInt8.writeInto(body.flags, buffer, start);
+    res = bufrw.UInt8.poolWriteInto(destResult, body.flags, buffer, start);
     if (!res.err) res.offset = offset;
 
     return res;

--- a/v2/error_response.js
+++ b/v2/error_response.js
@@ -21,8 +21,6 @@
 'use strict';
 
 var bufrw = require('bufrw');
-var WriteResult = bufrw.WriteResult;
-var ReadResult = bufrw.ReadResult;
 var Frame = require('./frame');
 var Tracing = require('./tracing');
 
@@ -287,26 +285,26 @@ ErrorResponse.CodeNames = CodeNames;
 ErrorResponse.CodeErrors = CodeErrors;
 
 ErrorResponse.RW = bufrw.Struct(ErrorResponse, [
-    {call: {writeInto: function writeGuard(body, buffer, offset) {
+    {call: {poolWriteInto: function writeGuard(destResult, body, buffer, offset) {
         if (CodeNames[body.code] === undefined) {
-            return WriteResult.error(errors.InvalidErrorCodeError({
+            return destResult.reset(errors.InvalidErrorCodeError({
                 errorCode: body.code,
                 tracing: body.tracing
             }), offset);
         }
-        return WriteResult.just(offset);
+        return destResult.reset(null, offset);
     }}},
     {name: 'code', rw: bufrw.UInt8},    // code:1
     {name: 'tracing', rw: Tracing.RW},  // tracing:25
     {name: 'message', rw: bufrw.str2},  // message~2
-    {call: {writeInto: function writeGuard(body, buffer, offset) {
+    {call: {poolWriteInto: function writeGuard(destResult, body, buffer, offset) {
         if (CodeNames[body.code] === undefined) {
-            return ReadResult.error(errors.InvalidErrorCodeError({
+            destResult.reset(errors.InvalidErrorCodeError({
                 errorCode: body.code,
                 tracing: body.tracing
             }), offset);
         }
-        return ReadResult.just(offset);
+        return destResult.reset(null, offset);
     }}}
 ]);
 

--- a/v2/handler.js
+++ b/v2/handler.js
@@ -41,6 +41,8 @@ var States = require('../reqres_states');
 var StreamingInRequest = require('../streaming_in_request');
 var StreamingInResponse = require('../streaming_in_response');
 
+var WriteResult = require('bufrw').WriteResult;
+
 var v2 = require('./index');
 var errors = require('../errors');
 
@@ -132,9 +134,10 @@ TChannelV2Handler.prototype.writeCopy = function writeCopy(buffer, start, end) {
     this.write(copy);
 };
 
+var writeRes = new WriteResult();
 TChannelV2Handler.prototype.pushFrame = function pushFrame(frame) {
     var writeBuffer = GLOBAL_WRITE_BUFFER;
-    var res = v2.Frame.RW.writeInto(frame, writeBuffer, 0);
+    var res = v2.Frame.RW.poolWriteInto(writeRes, frame, writeBuffer, 0);
     var err = res.err;
     if (err) {
         if (!Buffer.isBuffer(err.buffer)) {

--- a/v2/tracing.js
+++ b/v2/tracing.js
@@ -42,10 +42,11 @@ function Tracing(spanid, parentid, traceid, flags) {
     this.flags = flags || 0;
 }
 
-Tracing.RW = bufrw.Base(tracingByteLength, readTracingFrom, writeTracingInto);
+Tracing.RW = bufrw.Base(tracingByteLength, readTracingFrom, writeTracingInto, true);
 
-function tracingByteLength() {
-    return bufrw.LengthResult.just(
+function tracingByteLength(destResult) {
+    return destResult.reset(
+        null,
         8 + // spanid:8
         8 + // parentid:8
         8 + // traceid:8
@@ -53,78 +54,78 @@ function tracingByteLength() {
     );
 }
 
-function writeTracingInto(tracing, buffer, offset) {
+function writeTracingInto(destResult, tracing, buffer, offset) {
     var res;
 
-    res = bufrw.UInt32BE.writeInto(tracing.spanid[0], buffer, offset);
+    res = bufrw.UInt32BE.poolWriteInto(destResult, tracing.spanid[0], buffer, offset);
     if (res.err) return res;
     offset = res.offset;
 
-    res = bufrw.UInt32BE.writeInto(tracing.spanid[1], buffer, offset);
+    res = bufrw.UInt32BE.poolWriteInto(destResult, tracing.spanid[1], buffer, offset);
     if (res.err) return res;
     offset = res.offset;
 
-    res = bufrw.UInt32BE.writeInto(tracing.parentid[0], buffer, offset);
+    res = bufrw.UInt32BE.poolWriteInto(destResult, tracing.parentid[0], buffer, offset);
     if (res.err) return res;
     offset = res.offset;
 
-    res = bufrw.UInt32BE.writeInto(tracing.parentid[1], buffer, offset);
+    res = bufrw.UInt32BE.poolWriteInto(destResult, tracing.parentid[1], buffer, offset);
     if (res.err) return res;
     offset = res.offset;
 
-    res = bufrw.UInt32BE.writeInto(tracing.traceid[0], buffer, offset);
+    res = bufrw.UInt32BE.poolWriteInto(destResult, tracing.traceid[0], buffer, offset);
     if (res.err) return res;
     offset = res.offset;
 
-    res = bufrw.UInt32BE.writeInto(tracing.traceid[1], buffer, offset);
+    res = bufrw.UInt32BE.poolWriteInto(destResult, tracing.traceid[1], buffer, offset);
     if (res.err) return res;
     offset = res.offset;
 
-    res = bufrw.UInt8.writeInto(tracing.flags, buffer, offset);
+    res = bufrw.UInt8.poolWriteInto(destResult, tracing.flags, buffer, offset);
 
     return res;
 }
 
-function readTracingFrom(buffer, offset) {
+function readTracingFrom(destResult, buffer, offset) {
     var tracing = new Tracing();
     var res;
 
-    res = bufrw.UInt32BE.readFrom(buffer, offset);
+    res = bufrw.UInt32BE.poolReadFrom(destResult, buffer, offset);
     if (res.err) return res;
     offset = res.offset;
     tracing.spanid[0] = res.value;
 
-    res = bufrw.UInt32BE.readFrom(buffer, offset);
+    res = bufrw.UInt32BE.poolReadFrom(destResult, buffer, offset);
     if (res.err) return res;
     offset = res.offset;
     tracing.spanid[1] = res.value;
 
-    res = bufrw.UInt32BE.readFrom(buffer, offset);
+    res = bufrw.UInt32BE.poolReadFrom(destResult, buffer, offset);
     if (res.err) return res;
     offset = res.offset;
     tracing.parentid[0] = res.value;
 
-    res = bufrw.UInt32BE.readFrom(buffer, offset);
+    res = bufrw.UInt32BE.poolReadFrom(destResult, buffer, offset);
     if (res.err) return res;
     offset = res.offset;
     tracing.parentid[1] = res.value;
 
-    res = bufrw.UInt32BE.readFrom(buffer, offset);
+    res = bufrw.UInt32BE.poolReadFrom(destResult, buffer, offset);
     if (res.err) return res;
     offset = res.offset;
     tracing.traceid[0] = res.value;
 
-    res = bufrw.UInt32BE.readFrom(buffer, offset);
+    res = bufrw.UInt32BE.poolReadFrom(destResult, buffer, offset);
     if (res.err) return res;
     offset = res.offset;
     tracing.traceid[1] = res.value;
 
-    res = bufrw.UInt8.readFrom(buffer, offset);
+    res = bufrw.UInt8.poolReadFrom(destResult, buffer, offset);
     if (res.err) return res;
     offset = res.offset;
     tracing.flags = res.value;
 
-    return bufrw.ReadResult.just(offset, tracing);
+    return destResult.reset(null, offset, tracing);
 }
 
 Tracing.emptyTracing = new Tracing();


### PR DESCRIPTION
On the path to lazy zero-alloc. This removes many allocations at the bufrw layer.

It also gets us a few hundred ops/sec faster for the eager path:

Before
```
1:          PING,  1000/0 min/max/avg/p95:    9/ 352/ 154.68/ 265.55   3211ms total,  6228.59 ops/sec
1:          PING,  1000/0 min/max/avg/p95:   17/ 295/ 146.34/ 253.00   3001ms total,  6664.45 ops/sec
1:          PING,  1000/0 min/max/avg/p95:   21/ 287/ 141.63/ 241.00   2903ms total,  6889.42 ops/sec
1:          PING,  1000/0 min/max/avg/p95:   21/ 282/ 141.81/ 241.00   2908ms total,  6877.58 ops/sec
```

After
```
1:          PING,  1000/0 min/max/avg/p95:    9/ 322/ 143.92/ 246.55   2989ms total,  6691.20 ops/sec
1:          PING,  1000/0 min/max/avg/p95:   10/ 288/ 139.48/ 235.55   2852ms total,  7012.62 ops/sec
1:          PING,  1000/0 min/max/avg/p95:   11/ 278/ 137.48/ 235.55   2812ms total,  7112.38 ops/sec
1:          PING,  1000/0 min/max/avg/p95:   10/ 282/ 141.41/ 242.00   2890ms total,  6920.42 ops/sec
```

r @jcorbin @kriskowal 