### PR TITLE
Fix node 0.10.42 bug around Content-Length

### DIFF
--- a/as/http.js
+++ b/as/http.js
@@ -448,6 +448,11 @@ TChannelHTTP.prototype._forwardToLBPool = function _forwardToLBPool(options, inr
     }
     options.encoding = null;
     var data = inreq.bodyStream || inreq.bodyArg; // lb_pool likes polymorphism
+
+    if (inreq.bodyArg) {
+        delete options.headers['transfer-encoding'];
+    }
+
     self.lbpool.request(options, data, onResponse);
 
     function onResponse(err, res, body) {

--- a/errors.js
+++ b/errors.js
@@ -655,7 +655,7 @@ Errors.classify = function classify(err) {
         return err.codeName;
     }
 
-    if (err.type.indexOf('bufrw.') > -1) {
+    if (err.type && err.type.indexOf('bufrw.') > -1) {
         return classifyBurwError(err);
     }
 

--- a/test/as-http.js
+++ b/test/as-http.js
@@ -234,7 +234,6 @@ allocHTTPTest('as/http can bridge a service using lbpool (non-streaming)', {
                         'max-forwards': '5',
                         host:  egressHost,
                         connection: 'keep-alive',
-                        'transfer-encoding': 'chunked',
                         'content-length': '11'
                     }
                 }


### PR DESCRIPTION
node 0.10.42 started enforcing HTTP 1.1 more strictly
and says that a request must NOT have both a
Content-Length and a Chunked-Encoding header.

This caused an issue for us in the `as/http`
implementation since we forward incoming requests
to lb_pool. When we forward we take a the 
Chunked-Encoding header and pass it to lb_pool as well
as passing it a Buffer for the body.

lb_pool will set the Content-Length header and this
creates an issue for the HTTP parser on the other
end.

In reality the `forwardToLBPool()` method does buffering
of the incoming HTTP request and therefore must strip
the Chunked-Encoding header as it's no longer doing
Chunked-Encoding

r: @rf @jcorbin @kriskowal