### PR TITLE
WIP: Associate ownership to error frames.

### DIFF
--- a/channel.js
+++ b/channel.js
@@ -132,6 +132,11 @@ function TChannel(options) {
     // Filled in by listening event:
     this.hostPort = null;
 
+    self.ownerName = self.options.ownerName;
+    if (!self.ownerName) {
+        self.ownerName = 'unknown-nodejs';
+    }
+
     // name of the service running over this channel
     this.serviceName = '';
     if (this.options.serviceName) {

--- a/v2/handler.js
+++ b/v2/handler.js
@@ -791,7 +791,11 @@ TChannelV2Handler.prototype.sendPingReponse = function sendPingReponse(res) {
     this.pushFrame(resFrame);
 };
 
-TChannelV2Handler.prototype.sendErrorFrame = function sendErrorFrame(id, tracing, codeString, message) {
+TChannelV2Handler.prototype.sendErrorFrame =
+function sendErrorFrame(id, tracing, codeString, message, ownerName) {
+    assert(typeof ownerName === 'string' && ownerName !== '',
+        'ownerName is a required parameter for `sendErrorFrame()`');
+
     var code = v2.ErrorResponse.Codes[codeString];
     if (code === undefined) {
         this.logger.error('invalid error frame code string', this.extendLogInfo({
@@ -800,6 +804,9 @@ TChannelV2Handler.prototype.sendErrorFrame = function sendErrorFrame(id, tracing
         code = v2.ErrorResponse.Codes.UnexpectedError;
         message = 'UNKNOWN CODE(' + codeString + '): ' + message;
     }
+
+    message = '[' + ownerName + ']: ' + message;
+
     var errBody = new v2.ErrorResponse(code, tracing, message);
     var errFrame = new v2.Frame(id, errBody);
     this.pushFrame(errFrame);

--- a/v2/out_response.js
+++ b/v2/out_response.js
@@ -23,6 +23,7 @@
 /* eslint-disable curly */
 
 var inherits = require('util').inherits;
+var assert = require('assert');
 
 var OutResponse = require('../out_response');
 var StreamingOutResponse = require('../streaming_out_response');
@@ -70,8 +71,12 @@ function _sendCallResponseCont(args, isLast) {
 
 V2OutResponse.prototype._sendError =
 V2StreamingOutResponse.prototype._sendError =
-function _sendError(codeString, message) {
-    this.handler.sendErrorFrame(this.id, this.tracing, codeString, message);
+function _sendError(codeString, message, ownerName) {
+    assert(ownerName && typeof ownerName === 'string', '_sendError()');
+
+    this.handler.sendErrorFrame(
+        this.id, this.tracing, codeString, message, ownerName
+    );
 };
 
 module.exports.OutResponse = V2OutResponse;


### PR DESCRIPTION
This changes marks the owner of an error frame inside
the message string.

The approach taken is to adjust the low level error
frame serialization to make ownerName mandatory.

From there on up we find all places where error frames
are send and verify whom the owner should be.

More work needs to be done on this branch.
