### PR TITLE
Log willSample replacer

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,5 +10,6 @@ env:
 - TCHANNEL_TEST_CONFIG=test/config/with_lazy_relay.json NPM_TEST_SCRIPT=travis
 - TCHANNEL_TEST_CONFIG=test/config/with_lazy_relay.json NPM_TEST_SCRIPT=hyperbahn-link-test
 - TCHANNEL_TEST_CONFIG= NPM_TEST_SCRIPT=tcurl-link-test
+- TCHANNEL_TEST_CONFIG= NPM_TEST_SCRIPT=log-replacer-test
 
 script: npm run $NPM_TEST_SCRIPT

--- a/channel.js
+++ b/channel.js
@@ -69,6 +69,8 @@ var BatchStatsd = require('./lib/statsd.js');
 
 var TracingAgent = require('./trace/agent');
 
+var coerceToLarch = require('larch/interface-converter'); 
+
 var CONN_STALE_PERIOD = 1500;
 var SANITY_PERIOD = 10 * 1000;
 
@@ -113,6 +115,7 @@ function TChannel(options) {
     }, options);
 
     this.logger = this.options.logger || nullLogger;
+    this.logger = coerceToLarch({logger: this.logger});
     this.random = this.options.random || globalRandom;
     this.timers = this.options.timers || globalTimers;
     this.initTimeout = this.options.initTimeout || 2000;

--- a/channel.js
+++ b/channel.js
@@ -47,7 +47,7 @@ var net = require('net');
 var format = require('util').format;
 var inherits = require('util').inherits;
 var inspect = require('util').inspect;
-var coerceToLarch = require('larch/interface-converter'); 
+var coerceToLarch = require('larch/interface-converter');
 
 var HostPort = require('./host-port.js');
 var nullLogger = require('./null-logger.js');

--- a/channel.js
+++ b/channel.js
@@ -47,6 +47,7 @@ var net = require('net');
 var format = require('util').format;
 var inherits = require('util').inherits;
 var inspect = require('util').inspect;
+var coerceToLarch = require('larch/interface-converter'); 
 
 var HostPort = require('./host-port.js');
 var nullLogger = require('./null-logger.js');
@@ -68,8 +69,6 @@ var CountedReadySignal = require('ready-signal/counted');
 var BatchStatsd = require('./lib/statsd.js');
 
 var TracingAgent = require('./trace/agent');
-
-var coerceToLarch = require('larch/interface-converter'); 
 
 var CONN_STALE_PERIOD = 1500;
 var SANITY_PERIOD = 10 * 1000;

--- a/hyperbahn-client.js
+++ b/hyperbahn-client.js
@@ -29,7 +29,7 @@ var util = require('util');
 var EventEmitter = require('events').EventEmitter;
 var safeJsonParse = require('safe-json-parse/tuple');
 var path = require('path');
-var coerceToLarch = require('larch/interface-converter'); 
+var coerceToLarch = require('larch/interface-converter');
 
 var Reporter = require('./tcollector/reporter.js');
 var TChannelJSON = require('./as/json.js');

--- a/hyperbahn-client.js
+++ b/hyperbahn-client.js
@@ -29,6 +29,7 @@ var util = require('util');
 var EventEmitter = require('events').EventEmitter;
 var safeJsonParse = require('safe-json-parse/tuple');
 var path = require('path');
+var coerceToLarch = require('larch/interface-converter'); 
 
 var Reporter = require('./tcollector/reporter.js');
 var TChannelJSON = require('./as/json.js');
@@ -124,6 +125,7 @@ function HyperbahnClient(options) {
     self.errorRetryTimes = options.errorRetryTimes || DEFAULT_ERROR_RETRY_TIMES;
 
     self.logger = options.logger || self.tchannel.logger;
+    self.logger = coerceToLarch({logger: self.logger});
     self.statsd = options.statsd;
 
     self.reporter = Reporter({

--- a/null-logger.js
+++ b/null-logger.js
@@ -27,5 +27,6 @@ module.exports = {
     error: noop,
     fatal: noop,
     info: noop,
-    warn: noop
+    warn: noop,
+    writeEntry: noop
 };

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "test": "npm run check-licence && npm run lint -s && npm run cover -s && npm run check-benchmark -s",
     "benchmark": "echo '!!! DEPRECATED: Better to just run `node benchmarks` directly' >&2; node benchmarks",
     "hyperbahn-link-test": "./test/link_hyperbahn.sh",
+    "log-replacer-test": "./replacer.sh; node test",
     "tcurl-link-test": "./test/link_tcurl.sh",
     "check-benchmark": "node benchmarks -- -r 10000 -p 100",
     "take-benchmark": "make -C benchmarks take",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "error": "^7.0.1",
     "farmhash": "1.1.0",
     "json-stringify-safe": "^5.0.0",
-    "larch": "^1.2.0",
+    "larch": "^1.2.1",
     "metrics": "^0.1.8",
     "minimist": "^1.1.0",
     "process": "0.11.1",

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "chalk": "^1.0.0",
     "child_pty": "3.0.1",
     "collect-parallel": "^1.0.1",
-    "debug-logtron": "5.1.1",
+    "debug-logtron": "^5.2.0",
     "duplexer": "^0.1.1",
     "eslint": "0.24.0",
     "eslint-config-perf-standard": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "lb_pool": "^1.4.0",
     "ldjson-stream": "^1.2.1",
     "loadtest": "1.2.14",
+    "logtron": "^8.11.1",
     "my-local-ip": "1.0.0",
     "once": "^1.3.1",
     "opn": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "error": "^7.0.1",
     "farmhash": "1.1.0",
     "json-stringify-safe": "^5.0.0",
+    "larch": "^1.2.0",
     "metrics": "^0.1.8",
     "minimist": "^1.1.0",
     "process": "0.11.1",

--- a/publish.sh
+++ b/publish.sh
@@ -58,6 +58,9 @@ git ls-files | grep '.js$' | grep -v 'bin/' | grep -v test | grep -v replacer.js
 # need a temp commit because git archive uses HEAD
 git commit -a -m 'temp commit'
 
+# run test with preprocessing done
+node test
+
 git archive --prefix=package/ --format tgz HEAD >package.tgz
 ${NPM:-npm} publish --registry=https://registry.npmjs.org/ package.tgz --tag "${NPM_TAG:-alpha}"
 rm package.tgz

--- a/publish.sh
+++ b/publish.sh
@@ -52,7 +52,16 @@ else
     git push origin --tags
 fi
 
+# run the replacer script to make all logsites check for sampling
+git ls-files | grep '.js$' | grep -v 'bin/' | grep -v test | grep -v replacer.js | xargs node replacer.js
+
+# need a temp commit because git archive uses HEAD
+git commit -a -m 'temp commit'
+
 git archive --prefix=package/ --format tgz HEAD >package.tgz
 ${NPM:-npm} publish --registry=https://registry.npmjs.org/ package.tgz --tag "${NPM_TAG:-alpha}"
 rm package.tgz
 npm cache clean tchannel
+
+# undo temp commit
+git reset --hard HEAD~

--- a/publish.sh
+++ b/publish.sh
@@ -53,7 +53,7 @@ else
 fi
 
 # run the replacer script to make all logsites check for sampling
-git ls-files | grep '.js$' | grep -v 'bin/' | grep -v test | grep -v replacer.js | xargs node replacer.js
+bash ./replacer.sh
 
 # need a temp commit because git archive uses HEAD
 git commit -a -m 'temp commit'

--- a/replacer.js
+++ b/replacer.js
@@ -21,7 +21,6 @@
 'use strict';
 
 var fs = require('fs');
-var path = require('path');
 var console = require('console');
 var process = require('process');
 
@@ -80,7 +79,6 @@ function replace(filename, lineno, level, line, nextLine) {
 
 function fixFile(filepath, done) {
     fs.readFile(filepath, 'utf8', readDone);
-    var fullDestPath;
     var lines;
 
     function readDone(err, data) {

--- a/replacer.js
+++ b/replacer.js
@@ -1,0 +1,130 @@
+// Copyright (c) 2015 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+'use strict';
+
+var fs = require('fs');
+var path = require('path');
+var console = require('console');
+var process = require('process');
+
+var levels = ['debug', 'info', 'warn', 'error', 'trace'];
+
+// Finds the msg of a log call in the line or the following line. Note that it
+// preserves the quotes, so the returned string will already have ' around it
+function findMsg(restOfLine, nextLine) {
+    // try to get message
+    if (restOfLine.length > 2) {
+        var msgMatches = restOfLine.match(/\((['"][^{]*['"])/);
+        if (msgMatches) {
+            return msgMatches[1];
+        }
+
+        msgMatches = restOfLine.match(/\(([^,]*)/);
+        if (msgMatches) {
+            return msgMatches[1];
+        }
+    }
+
+    // Not on first line, must be on next line
+    msgMatches = nextLine.match(/ *(['"][^{]*['"])/);
+
+    if (!msgMatches) {
+        return null;
+    }
+
+    return msgMatches[1];
+}
+
+// Inserts an if (logger.willSample('level')) before a logsite for a particular
+// level
+function replace(filename, lineno, level, line, nextLine) {
+    if (line.indexOf('logger.' + level) !== -1) {
+        var matches = line.match(/( *)([_a-z\.]*logger).[a-z]*(.*)/);
+        if (!matches) {
+            throw new Error('couldn\'t match log line in replacer.js');
+        }
+        var whitespace = matches[1];
+        var logger = matches[2];
+        var restOfLine = matches[3];
+        var logMsg = findMsg(restOfLine, nextLine);
+        if (!logMsg) {
+            throw new Error('couldn\'t find log message for ' + filename + ':' + lineno);
+        }
+
+        var ifStatement = 'if (' + logger + '.willSample(\'' + level + '\', ' + logMsg + ')) ';
+        var logCall = logger + '.s' + level + restOfLine;
+
+        return whitespace + ifStatement + logCall;
+    } else {
+        return line;
+    }
+}
+
+function fixFile(filepath, done) {
+    fs.readFile(filepath, 'utf8', readDone);
+    var fullDestPath;
+    var lines;
+
+    function readDone(err, data) {
+        if (err) {
+            return done(err);
+        }
+
+        lines = data.split('\n');
+        var i;
+        var j;
+        for (i = 0; i < lines.length; i++) {
+            if (lines[i].indexOf('logger.') !== -1) {
+                for (j = 0; j < levels.length; j++) {
+                    lines[i] = replace(filepath, i, levels[j], lines[i], lines[i + 1]);
+                }
+            }
+        }
+
+        fs.writeFile(filepath, lines.join('\n'), done);
+    }
+}
+
+function main(argv) {
+    var inputFiles = argv.slice(2);
+    var i;
+    var todo = inputFiles.length;
+    for (i = 0; i < todo; i++) {
+        fixFile(inputFiles[i], fileDone);
+    }
+
+    function fileDone(err) {
+        if (err) {
+            throw err;
+        }
+
+        todo -= 1;
+
+        if (todo <= 0) {
+            /* eslint no-console:0 */
+            console.log('preprocessing done');
+        }
+    }
+}
+
+if (module === require.main) {
+    main(process.argv);
+}

--- a/replacer.sh
+++ b/replacer.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+# Copyright (c) 2015 Uber Technologies, Inc.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+git ls-files | grep '.js$' | grep -v 'bin/' | grep -v test | grep -v replacer.js | xargs node replacer.js

--- a/replacer.sh
+++ b/replacer.sh
@@ -20,4 +20,4 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
-git ls-files | grep '.js$' | grep -v 'bin/' | grep -v test | grep -v replacer.js | xargs node replacer.js
+git ls-files | grep '.js$' | grep -v 'bin/' | grep -v test | grep -v replacer.js | grep -v examples | xargs node replacer.js


### PR DESCRIPTION
This adds
- `replacer.js`, a script which replaces log calls with `if (logger.willSample('level', 'blah')) logger.level('blah')`
- new travis mode for running test suite with log calls rewritten
- converts loggers passed to TChannel or hyperbahn-client to Larch interface compatible loggers using Larch's interface converter

To test the willSample replacement, clone this branch and run `replacer.sh`.  You'll see a bunch of changes like

``` javascript
     function onError(err) {
         sent = true;
-        self.logger.warn('Handling request failed', {
+        if (self.logger.willSample('warn', 'Handling request failed')) self.logger.swarn('Handling request failed', {
             error: err
         });
```

Note that the link tests are going to fail since the Larch interface converter doesn't recognize `DebugLogtron`s that don't follow the `Logtron` interface, i.e. are pre-5.2.0, which includes https://github.com/Raynos/debug-logtron/pull/4. TCurl and Hyperbahn still have an old version of `DebugLogtron`.

r @Raynos @jcorbin @kriskowal 
