### PR TITLE
RFC: Carry response remoteAddr on TChannel{JSON,Thrift}Response

### DIFF
--- a/as/json.js
+++ b/as/json.js
@@ -151,6 +151,7 @@ function TChannelJSONResponse(response, parseResult) {
         self.body = errors.ReconstructedError(parseResult.body);
     }
 
+    self.remoteAddr = response.remoteAddr;
     self.headers = response.headers;
 }
 

--- a/as/thrift.js
+++ b/as/thrift.js
@@ -508,6 +508,7 @@ function TChannelThriftResponse(response, parseResult) {
     self.ok = response.ok;
     self.head = parseResult.head;
     self.body = null;
+    self.remoteAddr = response.remoteAddr;
     self.headers = response.headers;
     self.body = parseResult.body;
     self.typeName = parseResult.typeName;


### PR DESCRIPTION
So I needed this while writing a hyperbahn test to log which node I happened to
advertise to/register with.

Personally I feel like the specialized responses should either carry the entire
wire response object, or some sort of more general "context" then just
headers... things missing still:
- span
- start time
- any outgoing req parts

cc @kriskowal @raynos