### PR TITLE
add stopWaitingForIdentified and use in LazyRelayInreq

### DIFF
--- a/lazy_relay.js
+++ b/lazy_relay.js
@@ -74,6 +74,10 @@ function LazyRelayInReq(conn, reqFrame) {
     }
 
     function onIdentified(err) {
+        // The ident descriptor will be cleared out of the peer when the ident
+        // comes back, so this slot id will be invalid once ident happens.
+        self.waitForIdentSlot = -1;
+
         if (err) {
             self.onError(err);
         } else {

--- a/peer.js
+++ b/peer.js
@@ -733,7 +733,7 @@ function WaitForIdentifiedDescriptor(close, error, ident, conn) {
     this.conn = null;
 }
 
-WaitForIdentifiedDescriptor.prototype.reset = 
+WaitForIdentifiedDescriptor.prototype.reset =
 function reset(close, error, ident, conn) {
     this.close = close;
     this.error = error;

--- a/test/relay_lazy.js
+++ b/test/relay_lazy.js
@@ -301,6 +301,7 @@ allocCluster.test('lazy relay request times out', {
 
     var relayOutPeer = relayChan.peers.get(dest.hostPort);
     relayOutPeer.waitForIdentified = function punchWaitForIdentified() {
+        return -1;
     };
 
     sourceChan.request({

--- a/test/relay_lazy.js
+++ b/test/relay_lazy.js
@@ -443,7 +443,7 @@ allocCluster.test('relay request handles channel close correctly', {
                      'tchannel.connection.reset',
                      'expected connection error');
         assert.notOk(res, 'expected no response');
-        finish();
+        process.nextTick(finish);
     }
 
     function finish() {


### PR DESCRIPTION
Adds a method called `stopWaitingForIdentified` on peers. Uses a descriptor table to keep track of what needs to be released.

Note that there is a `free` added to the end of `LazyRelayInReq#onError`. This `free` would cause test failures but for the `stopWaitingForIdentified` method and its use in `LazyRelayInReq#clear`, hence the lack of tests; this condition is already sufficiently stressed.

This `free` added to the bottom of `onError` is (at least one of) the missing `free`s that are causing the object pool to not reuse objects right now in prod.

r @jcorbin @Raynos 