### PR TITLE
ObjectPool: use batch stats

### DIFF
--- a/channel.js
+++ b/channel.js
@@ -258,7 +258,8 @@ function TChannel(options) {
         ObjectPool.bootstrap({
             channel: this,
             reportInterval: 5000,
-            timers: this.timers
+            timers: this.timers,
+            debug: this.options.objectPoolDebug ? true : false
         });
     }
 

--- a/channel.js
+++ b/channel.js
@@ -230,14 +230,6 @@ function TChannel(options) {
     this.statsd = this.options.statsd;
     this.batchStats = null;
 
-    if (this.statsd) {
-        ObjectPool.bootstrap({
-            statsd: this.statsd,
-            reportInterval: 1000,
-            timers: this.timers
-        });
-    }
-
     this.requestDefaults = this.options.requestDefaults ?
         new RequestDefaults(this.options.requestDefaults) : null;
 
@@ -260,6 +252,14 @@ function TChannel(options) {
         this.sanityTimer = this.timers.setTimeout(doSanitySweep, SANITY_PERIOD);
     } else {
         this.batchStats = this.topChannel.batchStats;
+    }
+
+    if (this.batchStats) {
+        ObjectPool.bootstrap({
+            channel: this,
+            reportInterval: 5000,
+            timers: this.timers
+        });
     }
 
     this.maximumRelayTTL = MAXIMUM_TTL_ALLOWED;
@@ -918,7 +918,7 @@ TChannel.prototype.close = function close(callback) {
 
     var counter = 1;
 
-    if (self.statsd) {
+    if (self.batchStats) {
         ObjectPool.unref();
     }
 

--- a/lib/object_pool.js
+++ b/lib/object_pool.js
@@ -21,6 +21,7 @@
 'use strict';
 
 var assert = require('assert');
+var stat = require('../stat-tags');
 
 var DEFAULT_MAX_SIZE = 1000;
 
@@ -42,11 +43,19 @@ function ObjectPool(options) {
 
     this.freeList = [];
     this.outstanding = 0;
-    this.freeStatName = 'object-pools.' + this.name + '.free';
-    this.outstandingStatName = 'object-pools.' + this.name + '.outstanding';
+
+    this.freeListStatTags = new stat.ObjectPoolTags(
+        this.name,
+        'free'
+    );
+
+    this.outstandingStatTags = new stat.ObjectPoolTags(
+        this.name,
+        'outstanding'
+    );
 }
 
-ObjectPool.statsd = null;
+ObjectPool.channel = null;
 ObjectPool.reportInterval = null;
 ObjectPool.timers = null;
 ObjectPool.pools = [];
@@ -82,11 +91,11 @@ ObjectPool.bootstrap = function bootstrap(options) {
     assert(typeof options === 'object', 'expected options object');
 
     assert(
-        typeof options.statsd === 'object' &&
-        typeof options.statsd.gauge === 'function',
-        'expected options.statsd to be statsd instance'
+        typeof options.channel === 'object' &&
+        typeof options.channel.emitFastStat === 'function',
+        'expected options.channel to be TChannel instance'
     );
-    ObjectPool.statsd = options.statsd;
+    ObjectPool.channel = options.channel;
 
     assert(
         typeof options.reportInterval === 'number',
@@ -120,7 +129,7 @@ ObjectPool.reportStats = function reportStats() {
 
     var i;
     for (i = 0; i < ObjectPool.pools.length; i++) {
-        ObjectPool.pools[i].reportStats(ObjectPool.statsd);
+        ObjectPool.pools[i].reportStats(ObjectPool.channel);
     }
 
     ObjectPool.timer = ObjectPool.timers.setTimeout(
@@ -129,16 +138,19 @@ ObjectPool.reportStats = function reportStats() {
     );
 };
 
-ObjectPool.prototype.reportStats = function reportStats(statsd) {
-    statsd.gauge(
-        this.freeStatName,
-        this.freeList.length
+ObjectPool.prototype.reportStats = function reportStats(channel) {
+    channel.emitFastStat(
+        'tchannel.object-pool',
+        'gauge',
+        this.freeList.length,
+        this.freeListStatTags
     );
 
-    // This stat is how we infer the maxSize property
-    statsd.gauge(
-        this.outstandingStatName,
-        this.outstanding
+    channel.emitFastStat(
+        'tchannel.object-pool',
+        'gauge',
+        this.outstanding,
+        this.outstandingStatTags
     );
 };
 

--- a/lib/object_pool.js
+++ b/lib/object_pool.js
@@ -53,6 +53,9 @@ function ObjectPool(options) {
         this.name,
         'outstanding'
     );
+
+    // only used in debug mode
+    this.outstandingList = [];
 }
 
 ObjectPool.channel = null;
@@ -61,6 +64,7 @@ ObjectPool.timers = null;
 ObjectPool.pools = [];
 ObjectPool.timer = null;
 ObjectPool.refs = 0;
+ObjectPool.debug = false;
 
 ObjectPool.setup = function setup(options) {
     var pool = new ObjectPool(options);
@@ -109,6 +113,10 @@ ObjectPool.bootstrap = function bootstrap(options) {
         'expected options.timers to be timers object'
     );
     ObjectPool.timers = options.timers;
+
+    if (typeof options.debug === 'boolean') {
+        ObjectPool.debug = options.debug;
+    }
 
     ObjectPool.timer = ObjectPool.timers.setTimeout(
         ObjectPool.reportStats,
@@ -161,10 +169,20 @@ ObjectPool.prototype.get = function get() {
         inst = this.freeList.pop();
         assert(inst._objectPoolIsFreed, 'instance retreived from pool is free');
         inst._objectPoolIsFreed = false;
+
+        if (ObjectPool.debug) {
+            this.outstandingList.push(inst);
+        }
+
         return inst;
     } else {
         inst = new this.Type();
         inst._objectPoolIsFreed = false;
+
+        if (ObjectPool.debug) {
+            this.outstandingList.push(inst);
+        }
+
         return inst;
     }
 };
@@ -178,4 +196,14 @@ ObjectPool.prototype.free = function free(inst) {
         this.freeList.push(inst);
     }
     this.outstanding -= 1;
+
+    var i;
+    if (ObjectPool.debug) {
+        for (i = 0; i < this.outstandingList.length; i++) {
+            if (this.outstandingList[i] === inst) {
+                this.outstandingList.splice(i, 1);
+                return;
+            }
+        }
+    }
 };

--- a/relay_handler.js
+++ b/relay_handler.js
@@ -59,6 +59,7 @@ RelayHandler.prototype.handleLazily = function handleLazily(conn, reqFrame) {
     if (!rereq.peer) {
         rereq.sendErrorFrame('Declined', 'no peer available for request');
         self.logger.info('no relay peer available', rereq.extendLogInfo({}));
+        rereq.free();
         return true;
     }
 

--- a/stat-tags.js
+++ b/stat-tags.js
@@ -58,7 +58,8 @@ module.exports = {
     ConnectionsErrorsTags: ConnectionsErrorsTags,
     ConnectionsClosedTags: ConnectionsClosedTags,
     RelayLatencyTags: RelayLatencyTags,
-    HTTPHanlderBuildLatencyTags: HTTPHanlderBuildLatencyTags
+    HTTPHanlderBuildLatencyTags: HTTPHanlderBuildLatencyTags,
+    ObjectPoolTags: ObjectPoolTags
 };
 
 function InboundCallsRecvdTags(cn, serviceName, endpoint) {
@@ -662,4 +663,18 @@ HTTPHanlderBuildLatencyTags.prototype.toStatKey = function toStatKey(prefix) {
         clean(this.callerName, 'no-caller-name') + '.' +
         clean(this.targetService, 'no-target-service') + '.' +
         (this.streamed ? 'streamed' : 'unstreamed');
+};
+
+function ObjectPoolTags(poolName, statType) {
+    this.app = '';
+    this.host = '';
+    this.cluster = '';
+    this.version = '';
+
+    this.poolName = poolName;
+    this.statType = statType;
+}
+
+ObjectPoolTags.prototype.toStatKey = function toStatKey(prefix) {
+    return prefix + '.' + this.poolName + '.' + this.statType;
 };

--- a/stat-tags.js
+++ b/stat-tags.js
@@ -673,8 +673,16 @@ function ObjectPoolTags(poolName, statType) {
 
     this.poolName = poolName;
     this.statType = statType;
+
+    this._cachedPrefix = '';
+    this._key = '';
 }
 
 ObjectPoolTags.prototype.toStatKey = function toStatKey(prefix) {
-    return prefix + '.' + this.poolName + '.' + this.statType;
+    // prefix should never change but we store it in _cachedPrefix just in case
+    if (!this._key || prefix !== this._cachedPrefix) {
+        this._key = prefix + '.' + this.poolName + '.' + this.statType;
+        this._cachedPrefix = prefix;
+    }
+    return this._key;
 };

--- a/test/object_pool.js
+++ b/test/object_pool.js
@@ -47,10 +47,14 @@ ObjectPool.setup({
 test('object pool happy', function t1(assert) {
     var timers = Timer(0);
     var stats = {};
-    var statsd = {gauge: function (k, v) { stats[k] = v; }};
+    var channel = {emitFastStat: fakeEmitFastStat};
+
+    function fakeEmitFastStat(name, type, val, tags) {
+        stats[name + tags.toStatKey('')] = val;
+    }
 
     ObjectPool.bootstrap({
-        statsd: statsd,
+        channel: channel,
         timers: timers,
         reportInterval: 500
     });
@@ -89,8 +93,8 @@ test('object pool happy', function t1(assert) {
     assert.equal(pool.outstanding, 1, '1 outstanding instace');
 
     timers.advance(500);
-    assert.equal(stats['object-pools.Widget.free'], 1);
-    assert.equal(stats['object-pools.Widget.outstanding'], 1);
+    assert.equal(stats['tchannel.object-pool.Widget.free'], 1);
+    assert.equal(stats['tchannel.object-pool.Widget.outstanding'], 1);
 
     w = Widget.alloc();
 
@@ -108,8 +112,8 @@ test('object pool happy', function t1(assert) {
     assert.equal(pool.outstanding, 0, '0 outstanding instace');
 
     timers.advance(500);
-    assert.equal(stats['object-pools.Widget.free'], 2);
-    assert.equal(stats['object-pools.Widget.outstanding'], 0);
+    assert.equal(stats['tchannel.object-pool.Widget.free'], 2);
+    assert.equal(stats['tchannel.object-pool.Widget.outstanding'], 0);
 
     assert.end();
 });


### PR DESCRIPTION
Use batch stats in object pool. We don't actually pass a statsd to TChannel in Hyperbahn, so we have to use the batch statsd.

r @jcorbin @Raynos 