### PR TITLE
Free LazyRelayInReqs upon NoPeerAvailable; Object Pool verification

### DIFF
--- a/channel.js
+++ b/channel.js
@@ -258,7 +258,8 @@ function TChannel(options) {
         ObjectPool.bootstrap({
             channel: this,
             reportInterval: 5000,
-            timers: this.timers
+            timers: this.timers,
+            debug: this.options.objectPoolDebug ? true : false
         });
     }
 

--- a/lib/object_pool.js
+++ b/lib/object_pool.js
@@ -53,6 +53,9 @@ function ObjectPool(options) {
         this.name,
         'outstanding'
     );
+
+    // only used in debug mode
+    this.outstandingList = [];
 }
 
 ObjectPool.channel = null;
@@ -61,6 +64,7 @@ ObjectPool.timers = null;
 ObjectPool.pools = [];
 ObjectPool.timer = null;
 ObjectPool.refs = 0;
+ObjectPool.debug = false;
 
 ObjectPool.setup = function setup(options) {
     var pool = new ObjectPool(options);
@@ -109,6 +113,10 @@ ObjectPool.bootstrap = function bootstrap(options) {
         'expected options.timers to be timers object'
     );
     ObjectPool.timers = options.timers;
+
+    if (typeof options.debug === 'boolean') {
+        ObjectPool.debug = options.debug;
+    }
 
     ObjectPool.timer = ObjectPool.timers.setTimeout(
         ObjectPool.reportStats,
@@ -161,10 +169,20 @@ ObjectPool.prototype.get = function get() {
         inst = this.freeList.pop();
         assert(inst._objectPoolIsFreed, 'instance retreived from pool is free');
         inst._objectPoolIsFreed = false;
+
+        if (ObjectPool.debug) {
+            this.outstandingList.push(inst);
+        }
+
         return inst;
     } else {
         inst = new this.Type();
         inst._objectPoolIsFreed = false;
+
+        if (ObjectPool.debug) {
+            this.outstandingList.push(inst);
+        }
+
         return inst;
     }
 };
@@ -178,4 +196,13 @@ ObjectPool.prototype.free = function free(inst) {
         this.freeList.push(inst);
     }
     this.outstanding -= 1;
+
+    var i;
+    if (ObjectPool.debug) {
+        for (i = 0; i < this.outstandingList.length; i++) {
+            if (this.outstandingList[i] === inst) {
+                this.outstandingList.splice(i, 1);
+            }
+        }
+    }
 };

--- a/lib/object_pool.js
+++ b/lib/object_pool.js
@@ -202,6 +202,7 @@ ObjectPool.prototype.free = function free(inst) {
         for (i = 0; i < this.outstandingList.length; i++) {
             if (this.outstandingList[i] === inst) {
                 this.outstandingList.splice(i, 1);
+                return;
             }
         }
     }

--- a/relay_handler.js
+++ b/relay_handler.js
@@ -59,6 +59,7 @@ RelayHandler.prototype.handleLazily = function handleLazily(conn, reqFrame) {
     if (!rereq.peer) {
         rereq.sendErrorFrame('Declined', 'no peer available for request');
         self.logger.info('no relay peer available', rereq.extendLogInfo({}));
+        rereq.free();
         return true;
     }
 


### PR DESCRIPTION
Adds a verification step when tearing down a test cluster that ensures that all objects allocated using pools have been freed.

Adds a missing `LazyRelayInReq#free` upon no peer available.

Builds on #300 because they both modify the ObjectPool singelton.

r @raynos @jcorbin