### PR TITLE
WIP: LazyRelay{In,Out}Req: release time heap handle in #clear

### DIFF
--- a/lazy_relay.js
+++ b/lazy_relay.js
@@ -120,6 +120,10 @@ LazyRelayInReq.prototype.clear = function clear() {
         this.peer.stopWaitingForIdentified(this.waitForIdentSlot);
     }
 
+    if (this.timeHeapHandle) {
+        this.timeHeapHandle.cancel();
+    }
+
     this.channel = null;
     this.conn = null;
     this.start = null;
@@ -628,6 +632,10 @@ LazyRelayOutReq.prototype.reset = function reset(conn, inreq) {
 };
 
 LazyRelayOutReq.prototype.clear = function clear() {
+    if (this.timeHeapHandle) {
+        this.timeHeapHandle.cancel();
+    }
+
     this.channel = null;
     this.conn = null;
     this.start = null;


### PR DESCRIPTION
This should fix the uncaught we've seen in production:

```
TypeError: Cannot read property 'timers' of null
    at LazyRelayInReq.sendErrorFrame (/var/cache/udeploy/r/hyperbahn/sjc1-produ-0000000131-v1/node_modules/hyperbahn/node_modules/tchannel/lazy_relay.js:456:27)
    at LazyRelayInReq.onError (/var/cache/udeploy/r/hyperbahn/sjc1-produ-0000000131-v1/node_modules/hyperbahn/node_modules/tchannel/lazy_relay.js:439:10)
    at LazyRelayInReq.onTimeout (/var/cache/udeploy/r/hyperbahn/sjc1-produ-0000000131-v1/node_modules/hyperbahn/node_modules/tchannel/lazy_relay.js:267:10)
...
```

It's probably caused by not releasing time heap handles when we free the req objects. WIP because needs test.
