### PR TITLE
channel: default choose peer with heap to true

### DIFF
--- a/channel.js
+++ b/channel.js
@@ -122,7 +122,8 @@ function TChannel(options) {
     this.emitConnectionMetrics =
         typeof this.options.emitConnectionMetrics === 'boolean' ?
         this.options.emitConnectionMetrics : false;
-    this.choosePeerWithHeap = this.options.choosePeerWithHeap || false;
+    this.choosePeerWithHeap = typeof this.options.choosePeerWithHeap === 'boolean' ?
+        this.options.choosePeerWithHeap : true;
 
     this.setObservePeerScoreEvents(this.options.observePeerScoreEvents);
 


### PR DESCRIPTION
This change makes the peer heap the default in the
tchannel library. This means all users of tchannel
will go fast by default.

r: @jcorbin @rf @kriskowal