### PR TITLE
Shield againts calling `onError()` on null.

### DIFF
--- a/lazy_relay.js
+++ b/lazy_relay.js
@@ -718,7 +718,9 @@ function emitError(err) {
     // handleFrameLazily has completed.
     process.nextTick(deferInReqOnError);
     function deferInReqOnError() {
-        self.inreq.onError(err);
+        if (self.inreq) {
+            self.inreq.onError(err);
+        }
     }
 };
 


### PR DESCRIPTION
It might be possible for the same `inreq` to fail in multiple
ways in one tick of the event loop.

This means that other failures could free the inreq and it would
be gone.

Once we get to the nextTick we should do a best effort error
handling and if it's already freed assume that it failed with
a different but related error.

r: @jcorbin @rf