### PR TITLE
Fix a bunch of uncaught exceptions.

### DIFF
--- a/lazy_relay.js
+++ b/lazy_relay.js
@@ -768,6 +768,11 @@ function handleFrameLazily(frame) {
     // - v2.Types.ErrorResponse
     var self = this;
 
+    // ObjectPool weird free() issue; bail early
+    if (!self.inreq) {
+        return;
+    }
+
     frame.setId(self.inreq.id);
     self.inreq.conn.writeToSocket(frame.buffer);
     if (frame.bodyRW.lazy.isFrameTerminal(frame)) {

--- a/lazy_relay.js
+++ b/lazy_relay.js
@@ -679,6 +679,11 @@ LazyRelayOutReq.prototype.emitError =
 function emitError(err) {
     var self = this;
 
+    // ObjectPool weird free() issue; bail early
+    if (!self.channel) {
+        return;
+    }
+
     var now = self.channel.timers.now();
     var elapsed = now - self.start;
 

--- a/lazy_relay.js
+++ b/lazy_relay.js
@@ -740,6 +740,11 @@ LazyRelayOutReq.prototype.onTimeout =
 function onTimeout(now) {
     var self = this;
 
+    // ObjectPool weird free() issue; bail early
+    if (!self.conn) {
+        return;
+    }
+
     self.conn.ops.checkLastTimeoutTime(now);
     self.conn.ops.popOutReq(self.id, self.extendLogInfo({
         info: 'lazy out request timed out',

--- a/peer.js
+++ b/peer.js
@@ -431,6 +431,7 @@ function waitForIdentified(conn, callback) {
 TChannelPeer.prototype._waitForIdentified =
 function _waitForIdentified(conn, callback) {
     var self = this;
+    var called = false;
 
     // Setup an ident descriptor so we can stop waiting for identified later
     var slot = self.getIdentDescriptorSlot();
@@ -464,6 +465,12 @@ function _waitForIdentified(conn, callback) {
     }
 
     function finish(err) {
+        // Multiple events can trigger which causes double callback hilarity.
+        if (called) {
+            return;
+        }
+        called = true;
+
         self.stopWaitingForIdentified(slot);
         callback(err);
     }


### PR DESCRIPTION
There is a free() somewhere that isnt doing the right
thing. Freed objects are sticking around in pending
operations on the connection.

This causes a bunch of bugs with trying to error or
timeout a freed LazyOutReq/LazyInReq

I've added defense in depth to work around these
issues.

r: @jcorbin @rf