### PR TITLE
peer: add tryConnect() with backoff

### DIFF
--- a/peer.js
+++ b/peer.js
@@ -68,7 +68,9 @@ function TChannelPeer(channel, hostPort, options) {
     this.boundOnPendingChange = onPendingChange;
     this.scoreRange = null;
 
+    // Timestamp when next conn attempt is allowed
     this.nextConnAttemptTime = 0;
+    // How long to delay conn attempt by on failure (ms)
     this.nextConnAttemptDelay = 0;
 
     this.waitForIdentifiedListeners = [];

--- a/peer_heap.js
+++ b/peer_heap.js
@@ -148,7 +148,7 @@ PeerHeap.prototype.choose = function choose(threshold, filter) {
     }
 
     if (secondaryProbability > highestProbability && chosenPeer) {
-        chosenPeer.waitForIdentified(noop);
+        chosenPeer.tryConnect(noop);
         return secondaryPeer;
     }
 

--- a/sub_peers.js
+++ b/sub_peers.js
@@ -215,7 +215,7 @@ TChannelSubPeers.prototype.chooseLinearPeer = function chooseLinearPeer(req) {
     }
 
     if (secondaryScore > selectedScore && selectedPeer) {
-        selectedPeer.waitForIdentified(noop);
+        selectedPeer.tryConnect(noop);
         return secondaryPeer;
     }
 

--- a/test/peer-to-peer-load-balance.js
+++ b/test/peer-to-peer-load-balance.js
@@ -227,6 +227,7 @@ allocCluster.test('p2p requests where half of servers down', {
     }
 }, function t(cluster, assert) {
     cluster.logger.whitelist('info', 'resetting connection');
+
     setup(cluster, {
         minConnections: 5,
         servers: 8,
@@ -273,6 +274,10 @@ allocCluster.test('p2p requests where half of servers down', {
             p95: 600
         });
         cassert.report(assert, 'expected request distribution to be ok');
+
+        var logs = cluster.logger.items();
+        assert.ok(logs.length <= 280 + 160,
+            'expected conn reset logs (' + logs.length + ') to be <= 420');
 
         assert.end();
     }


### PR DESCRIPTION
There is an edge cases where the peer selection logic as
part of `minConnections` might try and open a lot of connections.

This can be quite expensive in terms of CPU & logging.

This change adds exponential backoff to trying to open a connection
on an unconnected peer when we have less connected peers then
minConnections.

There might be a scenario where you have minConnections: 4 and
numPeers: 5, except two of 5 peers are down. In that scenario
tchannel would try and open a lot of connections to the down
peers even though it should know that they are down.

The more general solution to this is remember whether a peer
is healthy or not.

r: @jcorbin @rf @kriskowal