### PR TITLE
lazy_relay: read res code, not res flags

### DIFF
--- a/lazy_relay.js
+++ b/lazy_relay.js
@@ -910,7 +910,7 @@ function _observeCallResFrame(frame, now) {
         self.inreq.circuit.state.onRequestHealthy();
     }
 
-    var res = frame.bodyRW.lazy.poolReadFlags(readRes, frame);
+    var res = frame.bodyRW.lazy.poolReadCode(readRes, frame);
     if (res.err) {
         self.logger.error('failed to read error frame code', self.extendLogInfo({
             error: res.err
@@ -918,8 +918,8 @@ function _observeCallResFrame(frame, now) {
         return;
     }
 
-    var flags = res.value;
-    var ok = flags === 0;
+    var code = res.value;
+    var ok = code === 0;
 
     if (ok) {
         self.channel.emitFastStat(

--- a/v2/call.js
+++ b/v2/call.js
@@ -650,6 +650,10 @@ CallResponse.RW.lazy.poolReadFlags = function poolReadFlags(destResult, frame) {
 CallResponse.RW.lazy.readFlags = allocifyPoolFn(CallResponse.RW.lazy.poolReadFlags, ReadResult);
 
 CallResponse.RW.lazy.codeOffset = CallResponse.RW.lazy.flagsOffset + 1;
+CallResponse.RW.lazy.poolReadCode = function poolReadCode(destResult, frame) {
+    // code:1
+    return bufrw.UInt8.poolReadFrom(destResult, frame.buffer, CallResponse.RW.lazy.codeOffset);
+};
 // TODO: readCode?
 
 CallResponse.RW.lazy.tracingOffset = CallResponse.RW.lazy.codeOffset + 1;


### PR DESCRIPTION
There is a bug where we read the resp flags, not the resp code.

This means our `app-error` stat is really a fragmentation stat
and not a thrift exception stat.

r: @kriskowal @jcorbin @blampe