### PR TITLE
Allow dynamically setting trace sample

### DIFF
--- a/channel.js
+++ b/channel.js
@@ -1060,10 +1060,27 @@ function setMaxTombstoneTTL(ttl) {
     }
 };
 
+// Set the traceSample value consistently throughout ALL channels.
+// This should be consistent everywhere in a channel tree for a whole app instance.
+// Principle of least surprise applies.
 TChannel.prototype.setTraceSample = function setTraceSample(traceSample) {
     var self = this;
-
     self.traceSample = traceSample;
+
+    var keys = Object.keys(self.subChannels);
+
+    // Set traceSample on subchannels recursively.
+    // Don't descend into trees that have already been updated.
+    for (var i = 0; i < keys.length; i++) {
+        var subChan = self.subChannels[keys[i]];
+
+        if (subChan.traceSample !== traceSample) {
+            subChan.setTraceSample(traceSample);
+        }
+    }
+
+    // Traverse to parent channels.
+    // Skip if the parent channel has already been updated.
     if (self.topChannel && self.topChannel.traceSample !== traceSample) {
         self.topChannel.setTraceSample(traceSample);
     }

--- a/channel.js
+++ b/channel.js
@@ -1067,10 +1067,9 @@ TChannel.prototype.setTraceSample = function setTraceSample(traceSample) {
     var self = this;
     self.traceSample = traceSample;
 
-    var keys = Object.keys(self.subChannels);
-
     // Set traceSample on subchannels recursively.
     // Don't descend into trees that have already been updated.
+    var keys = Object.keys(self.subChannels);
     for (var i = 0; i < keys.length; i++) {
         var subChan = self.subChannels[keys[i]];
 

--- a/channel.js
+++ b/channel.js
@@ -1060,4 +1060,13 @@ function setMaxTombstoneTTL(ttl) {
     }
 };
 
+TChannel.prototype.setTraceSample = function setTraceSample(traceSample) {
+    var self = this;
+
+    self.traceSample = traceSample;
+    if (self.topChannel && self.topChannel.traceSample !== traceSample) {
+        self.topChannel.setTraceSample(traceSample);
+    }
+};
+
 module.exports = TChannel;

--- a/test/trace/basic_server.js
+++ b/test/trace/basic_server.js
@@ -163,3 +163,17 @@ test('basic tracing test', function (assert) {
         }, 10);
     });
 });
+
+test('modifying traceSample', function (assert){
+    var channel = new TChannel();
+    var subservice = channel.makeSubChannel({
+        serviceName: 'subservice'
+    });
+    assert.equal(channel.traceSample, 0.01);
+    assert.equal(subservice.traceSample, 0.01);
+
+    subservice.setTraceSample(0.99);
+    assert.equal(channel.traceSample, 0.99);
+    assert.equal(subservice.traceSample, 0.99);
+    assert.end();
+});

--- a/test/trace/basic_server.js
+++ b/test/trace/basic_server.js
@@ -169,11 +169,22 @@ test('modifying traceSample', function (assert){
     var subservice = channel.makeSubChannel({
         serviceName: 'subservice'
     });
+    var subsubservice1 = subservice.makeSubChannel({
+        serviceName: 'subsubservice1'
+    });
+    var subsubservice2 = subservice.makeSubChannel({
+        serviceName: 'subsubservice2'
+    });
     assert.equal(channel.traceSample, 0.01);
     assert.equal(subservice.traceSample, 0.01);
+    assert.equal(subsubservice1.traceSample, 0.01);
+    assert.equal(subsubservice2.traceSample, 0.01);
 
     subservice.setTraceSample(0.99);
+
     assert.equal(channel.traceSample, 0.99);
     assert.equal(subservice.traceSample, 0.99);
+    assert.equal(subsubservice1.traceSample, 0.99);
+    assert.equal(subsubservice2.traceSample, 0.99);
     assert.end();
 });


### PR DESCRIPTION
This will allow us to dynamically adjust this from inside the jaeger tracing library, when we fetch a new sample rate.
