### PR TITLE
Remove ansi-color from devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,6 @@
     "xtend": "^4.0.0"
   },
   "devDependencies": {
-    "ansi-color": "^0.2.1",
     "async": "^0.9.0",
     "chalk": "^1.0.0",
     "child_pty": "3.0.1",


### PR DESCRIPTION
`ansi-color` doesn't need to be there - nothing used in the module itself uses it. Noticed it when looking through dependencies and saw that `chalk` was being used instead.