### PR TITLE
Work around problem with sendErrorFrame on reset lazy relay

### DIFF
--- a/lazy_relay.js
+++ b/lazy_relay.js
@@ -453,6 +453,11 @@ LazyRelayInReq.prototype.sendErrorFrame =
 function sendErrorFrame(codeName, message) {
     var self = this;
 
+    // ObjectPool weird free() issue; bail early
+    if (!self.channel) {
+        return;
+    }
+
     var now = self.channel.timers.now();
     self._observeInboundErrorFrame(now, codeName);
 


### PR DESCRIPTION
Observed an uncaught exception following this guard. Maybe we should fix the object pool.

r @raynos @jcorbin