### PR TITLE
Thread allowOptionalArguments through Thrift

### DIFF
--- a/as/thrift.js
+++ b/as/thrift.js
@@ -51,6 +51,7 @@ function TChannelAsThrift(opts) {
         strict: opts.strict,
         allowFilesystemAccess: true,
         allowIncludeAlias: opts.allowIncludeAlias,
+        allowOptionalArguments: opts.allowOptionalArguments,
         fs: opts.fs
     });
 

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "safe-json-parse": "^4.0.0",
     "sse4_crc32": "4.1.1",
     "tape-cluster": "2.1.0",
-    "thriftrw": "^3.4.3",
+    "thriftrw": "^3.5.0",
     "xorshift": "^0.2.0",
     "xtend": "^4.0.0"
   },


### PR DESCRIPTION
I’ve added a flag to the latest version of ThriftRW that allows users to opt-in for semantics regarding unmarked (not optional, not required) fields of argument structs that is consistent with the other ThriftRWs. We have lost the battle for required-only arguments. With the new semantics, arguments are optional by default and and you can opt-in for required.

r @jcorbin @Raynos 