### PR TITLE
support baseAppHeaders in as/json and as/thrift

### DIFF
--- a/as/json.js
+++ b/as/json.js
@@ -24,6 +24,7 @@ var Buffer = require('buffer').Buffer;
 var assert = require('assert');
 var Result = require('bufrw/result');
 var cyclicStringify = require('json-stringify-safe');
+var extend = require('xtend');
 
 var errors = require('../errors.js');
 
@@ -63,7 +64,11 @@ function send(endpoint, head, body, callback) {
     var self = this;
 
     var outreq = self.channel.request(self.reqOptions);
-    self.tchannelJSON.send(outreq, endpoint, head, body, callback);
+    var headers = head;
+    if (self.reqOptions.defaultRequestHeaders) {
+        headers = extend(self.reqOptions.defaultRequestHeaders, head);
+    }
+    self.tchannelJSON.send(outreq, endpoint, headers, body, callback);
 };
 
 TChannelJSON.prototype.request = function request(reqOptions) {

--- a/as/thrift.js
+++ b/as/thrift.js
@@ -26,6 +26,7 @@ var path = require('path');
 var bufrw = require('bufrw');
 var Result = require('bufrw/result');
 var thriftrw = require('thriftrw');
+var extend = require('xtend');
 
 var errors = require('../errors.js');
 var HeaderRW = require('../v2/header.js').header2;
@@ -527,7 +528,11 @@ function send(endpoint, head, body, callback) {
     var self = this;
 
     var outreq = self.channel.request(self.reqOptions);
-    self.tchannelThrift.send(outreq, endpoint, head, body, callback);
+    var headers = head;
+    if (self.reqOptions.defaultRequestHeaders) {
+        headers = extend(self.reqOptions.defaultRequestHeaders, head);
+    }
+    self.tchannelThrift.send(outreq, endpoint, headers, body, callback);
 };
 
 function health(tchannelThrift, req, head, body, callback) {


### PR DESCRIPTION
`baseAppHeaders` allow us to specify some app headers in the call to `request`.

r @kriskowal @Raynos 