### PR TITLE
Add free guard to LazyRelayInReq#onTimeout

### DIFF
--- a/lazy_relay.js
+++ b/lazy_relay.js
@@ -264,6 +264,11 @@ LazyRelayInReq.prototype.onTimeout =
 function onTimeout(now) {
     var self = this;
 
+    // ObjectPool weird free() issue; bail early
+    if (!self.channel) {
+        return;
+    }
+
     self.onError(errors.RequestTimeoutError({
         id: self.id,
         start: self.start,


### PR DESCRIPTION
r @raynos @kriskowal

Just adding a guard so this doesn't keep causing uncaughts and alerting