### PR TITLE
timeout should hold until last byte

### DIFF
--- a/in_request.js
+++ b/in_request.js
@@ -169,7 +169,10 @@ TChannelInRequest.prototype.onTimeout = function onTimeout(now) {
     var self = this;
     var timeoutError;
 
-    if (!self.res || self.res.state === States.Initial) {
+    if (!self.res ||
+        self.res.state === States.Initial ||
+        self.res.state === States.Streaming
+    ) {
         // TODO: send an error frame response?
         // TODO: emit error on self.res instead / in addition to?
         // TODO: should cancel any pending handler

--- a/out_request.js
+++ b/out_request.js
@@ -528,7 +528,9 @@ TChannelOutRequest.prototype.onTimeout = function onTimeout(now) {
         }));
     }
 
-    if (!self.res || self.res.state === States.Initial) {
+    if (!self.res || self.res.state === States.Initial ||
+        self.res.state === States.Streaming
+    ) {
         timeoutError = errors.RequestTimeoutError({
             id: self.id,
             start: self.start,


### PR DESCRIPTION
We've had an issue with the `rt-msg` service in production
where they were seeing multi-minute latencies, probably
because the timeout measure the time until the first call
response frame, not the last.

We had previously supported streaming by making the timeout
behave until the first call response frame.

However, this causes issues for people that encounter
fragmented call responses.

Since we have barely any streaming customers we should
recommend that people who use streaming and want timeout
until first response frame simply set a very large timeout
and a secondary custom timeout until the first response.

r: @ssyang @jcorbin @kriskowal