### PR TITLE
add a isUnhealthyError method into TChannel used for client-side throttling

### DIFF
--- a/channel.js
+++ b/channel.js
@@ -1073,4 +1073,12 @@ function setMaxTombstoneTTL(ttl) {
     }
 };
 
+TChannel.prototype.isUnhealthyError = function isUnhealthyError(err) {
+    if (!err) {
+        return false;
+    }
+    var codeName = errors.classify(err);
+    return errors.isUnhealthy(codeName);
+};
+
 module.exports = TChannel;

--- a/test/tchannel.js
+++ b/test/tchannel.js
@@ -138,3 +138,14 @@ test('make socket: should throw for invalid destination', function t(assert) {
     server.quit(assert.end);
   });
 });
+
+
+test('isUnhealthyError classifies errors correctly', function t(assert) {
+  var channel = new TChannel();
+  assert.notOk(channel.isUnhealthyError(null));
+  assert.notOk(channel.isUnhealthyError(new Error()));
+  assert.equal(null, channel.isUnhealthyError({ type: 'unknown' }));
+  assert.ok(channel.isUnhealthyError({ isErrorFrame: true, codeName: 'Busy' }));
+  assert.ok(channel.isUnhealthyError({ type: 'tchannel.connection.timeout' }));
+  channel.quit(assert.end);
+});


### PR DESCRIPTION
@Raynos suggested to do this so we don't have to import the tchannel dependency into our libs repo @syyang  @charliezhang 