### PR TITLE
Improve the connection backoff logic.

### DIFF
--- a/channel.js
+++ b/channel.js
@@ -125,6 +125,8 @@ function TChannel(options) {
         this.options.emitConnectionMetrics : false;
     this.choosePeerWithHeap = typeof this.options.choosePeerWithHeap === 'boolean' ?
         this.options.choosePeerWithHeap : true;
+    this.connectionAttemptDelay = this.options.connectionAttemptDelay;
+    this.maxConnectionAttemptDelay = this.options.maxConnectionAttemptDelay;
 
     this.setObservePeerScoreEvents(this.options.observePeerScoreEvents);
 

--- a/peer.js
+++ b/peer.js
@@ -75,6 +75,8 @@ function TChannelPeer(channel, hostPort, options) {
     this.nextConnAttemptTime = 0;
     // How long to delay conn attempt by on failure (ms)
     this.nextConnAttemptDelay = 0;
+    // Whether we are doing a connection attempt
+    this.hasConnectionAttempt = false;
 
     this.waitForIdentifiedListeners = [];
 
@@ -422,9 +424,12 @@ TChannelPeer.prototype.tryConnect = function tryConnect() {
     var self = this;
 
     var connectTime = Date.now();
-    if (connectTime < self.nextConnAttemptTime) {
+    if (connectTime < self.nextConnAttemptTime ||
+        self.hasConnectionAttempt
+    ) {
         return;
     }
+    self.hasConnectionAttempt = true;
 
     var conn = this.getOutConnection();
     if (!conn || conn.direction !== 'out') {
@@ -434,6 +439,8 @@ TChannelPeer.prototype.tryConnect = function tryConnect() {
     this.waitForIdentified(conn, onIdentified);
 
     function onIdentified(err) {
+        self.hasConnectionAttempt = false;
+
         if (!err) {
             self.nextConnAttemptDelay = 0;
             self.nextConnAttemptTime = 0;

--- a/peer.js
+++ b/peer.js
@@ -41,6 +41,7 @@ var ObjectPool = require('./lib/object_pool');
 var DEFAULT_REPORT_INTERVAL = 1000;
 var INITIAL_CONN_ATTEMPT_DELAY = 5000;
 var CONN_ATTEMPT_DELAY_MULTIPLER = 2;
+var MAX_CONN_ATTEMPT_DELAY = 30 * 1000;
 
 /*eslint max-statements: [2, 40]*/
 function TChannelPeer(channel, hostPort, options) {
@@ -445,6 +446,10 @@ TChannelPeer.prototype.tryConnect = function tryConnect() {
             self.nextConnAttemptDelay *= CONN_ATTEMPT_DELAY_MULTIPLER;
             // Add some amount of fuzz, +-100ms
             self.nextConnAttemptDelay += Math.floor(100 * (Math.random() - 0.5));
+
+            self.nextConnAttemptDelay = Math.min(
+                self.nextConnAttemptDelay, MAX_CONN_ATTEMPT_DELAY
+            );
         }
 
         var afterConnect = Date.now();

--- a/peer.js
+++ b/peer.js
@@ -464,8 +464,7 @@ TChannelPeer.prototype.tryConnect = function tryConnect() {
             // When in the past set next attempt to now + delay
             self.nextConnAttemptTime = afterConnect + self.nextConnAttemptDelay;
         } else {
-            // When in the future; go further in the future
-            self.nextConnAttemptTime += self.nextConnAttemptDelay;
+            // When in the future; leave it alone.
         }
     }
 };

--- a/peer.js
+++ b/peer.js
@@ -87,6 +87,11 @@ function TChannelPeer(channel, hostPort, options) {
         );
     }
 
+    this.connectionAttemptDelay = this.channel.connectionAttemptDelay ||
+        INITIAL_CONN_ATTEMPT_DELAY;
+    this.maxConnectionAttemptDelay = this.channel.maxConnectionAttemptDelay ||
+        MAX_CONN_ATTEMPT_DELAY;
+
     this.setPreferConnectionDirection(options.preferConnectionDirection || 'any');
 
     var self = this;
@@ -448,14 +453,14 @@ TChannelPeer.prototype.tryConnect = function tryConnect() {
         }
 
         if (self.nextConnAttemptDelay === 0) {
-            self.nextConnAttemptDelay = INITIAL_CONN_ATTEMPT_DELAY;
+            self.nextConnAttemptDelay = self.connectionAttemptDelay;
         } else {
             self.nextConnAttemptDelay *= CONN_ATTEMPT_DELAY_MULTIPLER;
             // Add some amount of fuzz, +-100ms
             self.nextConnAttemptDelay += Math.floor(100 * (Math.random() - 0.5));
 
             self.nextConnAttemptDelay = Math.min(
-                self.nextConnAttemptDelay, MAX_CONN_ATTEMPT_DELAY
+                self.nextConnAttemptDelay, self.maxConnectionAttemptDelay
             );
         }
 

--- a/sub_peers.js
+++ b/sub_peers.js
@@ -45,9 +45,13 @@ function TChannelSubPeers(channel, options) {
     this.boundOnOutConnectionDelta = boundOnOutConnectionDelta;
     this.boundOnRefreshConnectedPeers = boundOnRefreshConnectedPeers;
 
-    this.refreshTimer = setTimeout(
-        this.boundOnRefreshConnectedPeers, REFRESH_TIMER
-    );
+    this.refreshTimer = null;
+
+    if (this.hasMinConnections) {
+        this.refreshTimer = setTimeout(
+            this.boundOnRefreshConnectedPeers, REFRESH_TIMER
+        );
+    }
 
     function boundOnOutConnectionDelta(delta, peer) {
         self.onOutConnectionDelta(peer, delta);
@@ -91,7 +95,10 @@ function onOutConnectionDelta(peer, delta) {
 TChannelSubPeers.prototype.close = function close(callback) {
     var self = this;
 
-    clearTimeout(self.refreshTimer);
+    if (self.refreshTimer) {
+        clearTimeout(self.refreshTimer);
+    }
+
     var peers = self.values();
     TChannelPeersBase.prototype.close.call(self, peers, callback);
 };

--- a/sub_peers.js
+++ b/sub_peers.js
@@ -21,9 +21,13 @@
 'use strict';
 
 var inherits = require('util').inherits;
+var setTimeout = require('timers').setTimeout;
+var clearTimeout = require('timers').clearTimeout;
 
 var TChannelPeersBase = require('./peers_base.js');
 var PeerHeap = require('./peer_heap.js');
+
+var REFRESH_TIMER = 60 * 1000;
 
 function TChannelSubPeers(channel, options) {
     TChannelPeersBase.call(this, channel, options);
@@ -39,13 +43,39 @@ function TChannelSubPeers(channel, options) {
     this._heap = new PeerHeap(this, channel.random);
 
     this.boundOnOutConnectionDelta = boundOnOutConnectionDelta;
+    this.boundOnRefreshConnectedPeers = boundOnRefreshConnectedPeers;
+
+    this.refreshTimer = setTimeout(
+        this.boundOnRefreshConnectedPeers, REFRESH_TIMER
+    );
 
     function boundOnOutConnectionDelta(delta, peer) {
         self.onOutConnectionDelta(peer, delta);
     }
+
+    function boundOnRefreshConnectedPeers() {
+        this.refreshConnectedPeers();
+    }
 }
 
 inherits(TChannelSubPeers, TChannelPeersBase);
+
+TChannelSubPeers.prototype.refreshConnectedPeers =
+function refreshConnectedPeers() {
+    var peers = this.values();
+
+    var currentConnectedPeers = 0;
+    for (var i = 0; i < peers.length; i++) {
+        if (peers[i].countConnections('out') > 0) {
+            currentConnectedPeers++;
+        }
+    }
+
+    this.currentConnectedPeers = currentConnectedPeers;
+    this.refreshTimer = setTimeout(
+        this.boundOnRefreshConnectedPeers, REFRESH_TIMER
+    );
+};
 
 TChannelSubPeers.prototype.onOutConnectionDelta =
 function onOutConnectionDelta(peer, delta) {
@@ -61,6 +91,7 @@ function onOutConnectionDelta(peer, delta) {
 TChannelSubPeers.prototype.close = function close(callback) {
     var self = this;
 
+    clearTimeout(self.refreshTimer);
     var peers = self.values();
     TChannelPeersBase.prototype.close.call(self, peers, callback);
 };


### PR DESCRIPTION
It looks like in production we backoff far too aggressively.

This is caused by having multiple concurrent `tryConnect()` attempts
which will all "succeed" or "fail" and thus apply the doubling
logic many times ballooning the retry attempt delay.

I've also added a hard gap of 30s backoff so every 30s we will
try to open the connection.

r: @syyang