### PR TITLE
pass req through to `isBusy()`

### DIFF
--- a/service-name-handler.js
+++ b/service-name-handler.js
@@ -81,7 +81,7 @@ TChannelServiceNameHandler.prototype.handleRequest = function handleRequest(req,
     var self = this;
 
     if (self.isBusy) {
-        var busyInfo = self.isBusy();
+        var busyInfo = self.isBusy(req);
         if (busyInfo) {
             buildRes().sendError('Busy', busyInfo);
             return;


### PR DESCRIPTION
This allows us to make `isBusy()` decisions based
on InRequest information.

r: @rf