### PR TITLE
introducing openTracer without removing old-style tracing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ benchmarks/*.svg
 benchmarks/*.raw
 benchmarks/*.html
 benchmarks/*.folded
+.idea/
+tchannel-node.iml

--- a/as/json.js
+++ b/as/json.js
@@ -91,7 +91,7 @@ TChannelJSON.prototype.send = function send(
 ) {
 
     var self = this;
-    req.openSpan = req.channel.startSpan(head);
+    req.channel.startSpan(req, head);
 
     if (!self.logger) {
         self.logger = req.channel.logger;
@@ -194,7 +194,7 @@ TChannelJSON.prototype.register = function register(
         }
 
         var v = parseResult.value;
-        req.openSpan = req.channel.startSpan(v.head);
+        req.channel.startSpan(req, v.head);
         handlerFunc(opts, req, v.head, v.body, onResponse);
 
         function onResponse(err, respObject) {

--- a/as/json.js
+++ b/as/json.js
@@ -122,7 +122,7 @@ TChannelJSON.prototype.send = function send(
     );
 
     function onResponse(err, resp, arg2, arg3) {
-        req.channel.finishSpan(req.openSpan, err);
+        req.channel.finishSpan(req, err);
         if (err) {
             return callback(err);
         }
@@ -198,7 +198,7 @@ TChannelJSON.prototype.register = function register(
         handlerFunc(opts, req, v.head, v.body, onResponse);
 
         function onResponse(err, respObject) {
-            req.channel.finishSpan(req.openSpan, err);
+            req.channel.finishSpan(req, err);
             if (err) {
                 self.logger.error('Got unexpected error in handler', {
                     endpoint: arg1,

--- a/as/json.js
+++ b/as/json.js
@@ -91,6 +91,7 @@ TChannelJSON.prototype.send = function send(
 ) {
 
     var self = this;
+    req.openSpan = req.channel.startSpan(head);
 
     if (!self.logger) {
         self.logger = req.channel.logger;
@@ -121,6 +122,7 @@ TChannelJSON.prototype.send = function send(
     );
 
     function onResponse(err, resp, arg2, arg3) {
+        req.channel.finishSpan(req.openSpan, err);
         if (err) {
             return callback(err);
         }
@@ -192,9 +194,11 @@ TChannelJSON.prototype.register = function register(
         }
 
         var v = parseResult.value;
+        req.openSpan = req.channel.startSpan(v.head);
         handlerFunc(opts, req, v.head, v.body, onResponse);
 
         function onResponse(err, respObject) {
+            req.channel.finishSpan(req.openSpan, err);
             if (err) {
                 self.logger.error('Got unexpected error in handler', {
                     endpoint: arg1,

--- a/as/thrift.js
+++ b/as/thrift.js
@@ -253,7 +253,7 @@ function register(channel, name, opts, handle, spec) {
         handle(opts, req, v.head, v.body, handleThriftResponse);
 
         function handleThriftResponse(err, thriftRes) {
-            req.channel.finishSpan(req.openSpan, err);
+            req.channel.finishSpan(req, err);
             if (err) {
                 self.logger.error('Got unexpected error in handler', {
                     endpoint: name,
@@ -335,7 +335,7 @@ function send(request, endpoint, outHead, outBody, callback) {
     );
 
     function handleResponse(err, res, arg2, arg3) {
-        request.channel.finishSpan(request.openSpan, err);
+        request.channel.finishSpan(request, err);
         if (err) {
             return callback(err);
         }

--- a/as/thrift.js
+++ b/as/thrift.js
@@ -249,7 +249,7 @@ function register(channel, name, opts, handle, spec) {
 
         var v = parseResult.value;
 
-        req.openSpan = req.channel.startSpan(v.head);
+        req.channel.startSpan(req, v.head);
         handle(opts, req, v.head, v.body, handleThriftResponse);
 
         function handleThriftResponse(err, thriftRes) {
@@ -305,7 +305,7 @@ TChannelAsThrift.prototype.send =
 function send(request, endpoint, outHead, outBody, callback) {
     var self = this;
 
-    request.openSpan = request.channel.startSpan(outHead);
+    request.channel.startSpan(request, outHead);
 
     self.logger = self.logger || request.channel.logger;
 

--- a/channel.js
+++ b/channel.js
@@ -1083,15 +1083,14 @@ TChannel.prototype.isUnhealthyError = function isUnhealthyError(err) {
 };
 
 // TODO - make this do smart things
-TChannel.prototype.startSpan = function startSpan(head) {
+TChannel.prototype.startSpan = function startSpan(req, head) {
     var self = this;
     if (self.tracer) {
-        return self.tracer.openTracer.startSpan('TODO');
+        req.openSpan = self.tracer.openTracer.startSpan('TODO');
     }
-    return null;
 };
 
-TChannel.prototype.finishSpan = function startSpan(openSpan, err) {
+TChannel.prototype.finishSpan = function endSpan(openSpan, err) {
     if (openSpan) {
         if (err) {
             openSpan.setTag('err', err);

--- a/channel.js
+++ b/channel.js
@@ -212,7 +212,8 @@ function TChannel(options) {
             logger: this.logger,
             forceTrace: this.options.forceTrace,
             serviceName: this.options.serviceNameOverwrite,
-            reporter: this.options.traceReporter
+            reporter: this.options.traceReporter,
+            openTracer: this.options.openTracer
         });
     }
 
@@ -1079,6 +1080,24 @@ TChannel.prototype.isUnhealthyError = function isUnhealthyError(err) {
     }
     var codeName = errors.classify(err);
     return errors.isUnhealthy(codeName);
+};
+
+// TODO - make this do smart things
+TChannel.prototype.startSpan = function startSpan(head) {
+    var self = this;
+    if (self.tracer) {
+        return self.tracer.openTracer.startSpan('TODO');
+    }
+    return null;
+};
+
+TChannel.prototype.finishSpan = function startSpan(openSpan, err) {
+    if (openSpan) {
+        if (err) {
+            openSpan.setTag('err', err);
+        }
+        openSpan.finish();
+    }
 };
 
 module.exports = TChannel;

--- a/channel.js
+++ b/channel.js
@@ -1090,12 +1090,12 @@ TChannel.prototype.startSpan = function startSpan(req, head) {
     }
 };
 
-TChannel.prototype.finishSpan = function endSpan(openSpan, err) {
-    if (openSpan) {
+TChannel.prototype.finishSpan = function finishSpan(req, err) {
+    if (req.openSpan) {
         if (err) {
-            openSpan.setTag('err', err);
+            req.openSpan.setTag('err', err);
         }
-        openSpan.finish();
+        req.openSpan.finish();
     }
 };
 

--- a/connection.js
+++ b/connection.js
@@ -724,6 +724,7 @@ TChannelConnection.prototype.onCallResponse = function onCallResponse(res) {
         req.span.annotate('cr');
         self.tracer.report(req.span);
         res.span = req.span;
+        res.openSpan = req.openSpan;
     }
 
     req.emitResponse(res);
@@ -939,6 +940,7 @@ TChannelConnection.prototype.buildOutResponse = function buildOutResponse(req, o
 
     options.tracing = req.tracing;
     options.span = req.span;
+    options.openSpan = req.span;
     options.checksumType = req.checksum && req.checksum.type;
 
     // TODO: take over popInReq on req/res error?

--- a/in_request.js
+++ b/in_request.js
@@ -60,6 +60,7 @@ function TChannelInRequest(id, options) {
     this.arg3 = emptyBuffer;
     this.forwardTrace = false;
     this.span = null;
+    this.openSpan = null;
     this.start = this.channel.timers.now();
     this.res = null;
     this.err = null;

--- a/in_response.js
+++ b/in_response.js
@@ -49,7 +49,7 @@ function TChannelInResponse(id, options) {
     self.headers = options.headers || {};
     self.ok = self.code === 0; // TODO: probably okay, but a bit jank
     self.span = options.span || null;
-    self.openSpan = options.openSpan || null;
+    self.openSpan = options.openSpan;
 
     self.streamed = false;
     self._argstream = null;

--- a/in_response.js
+++ b/in_response.js
@@ -49,6 +49,7 @@ function TChannelInResponse(id, options) {
     self.headers = options.headers || {};
     self.ok = self.code === 0; // TODO: probably okay, but a bit jank
     self.span = options.span || null;
+    self.openSpan = options.openSpan || null;
 
     self.streamed = false;
     self._argstream = null;

--- a/out_request.js
+++ b/out_request.js
@@ -261,6 +261,7 @@ TChannelOutRequest.prototype.emitResponse = function emitResponse(res) {
 
     self.res = res;
     self.res.span = self.span;
+    self.res.openSpan = self.openSpan;
 
     if (!self.res.streamed) {
         self.markEnd();

--- a/out_response.js
+++ b/out_response.js
@@ -53,6 +53,7 @@ function TChannelOutResponse(id, options) {
     self.checksum = options.checksum || null;
     self.ok = self.code === 0;
     self.span = options.span || null;
+    self.openSpan = options.openSpan || null;
     self.streamed = false;
     self._argstream = null;
     self.arg1 = null;

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "json-stringify-safe": "^5.0.0",
     "metrics": "^0.1.8",
     "minimist": "^1.1.0",
+    "opentracing": "^0.11.1",
     "process": "0.11.1",
     "raw-body": "^2.1.2",
     "ready-signal": "^1.1.1",

--- a/test/index.js
+++ b/test/index.js
@@ -83,6 +83,8 @@ require('./peer-file-watcher.js');
 require('./trace/basic_server.js');
 require('./trace/server_2_requests.js');
 require('./trace/outpeer_span_handle.js');
+require('./trace/basic_json_server.js');
+require('./trace/basic_thrift_server.js');
 
 require('./v2/frame.js');
 require('./v2/init.js');

--- a/test/trace/basic_json_server.js
+++ b/test/trace/basic_json_server.js
@@ -1,0 +1,102 @@
+// Copyright (c) 2016 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+var DebugLogtron = require('debug-logtron');
+var test = require('tape');
+
+var TChannel = require('../../channel.js');
+var TChannelJSON = require('../../as/json');
+
+var openTracing = require('opentracing');
+var logger = DebugLogtron('tchannel');
+
+test('basic json tracing test', function (assert) {
+
+    var spans = [];
+
+    var oTracer = openTracing;
+
+    function traceReporter(span) {
+        spans.push(span);
+        logger.debug(span.toString());
+    }
+
+    var server = TChannel({
+        serviceName: 'server',
+        logger: logger,
+        traceReporter: traceReporter,
+        traceSample: 1,
+        trace: true,
+        openTracer: oTracer
+    });
+    var client = TChannel({
+        logger: logger,
+        traceReporter: traceReporter,
+        traceSample: 1,
+        trace: true,
+        openTracer: oTracer
+    });
+    var tchannelJSON = TChannelJSON();
+
+    var context = {};
+
+    tchannelJSON.register(server, 'echo', context, echo);
+    function echo(context, req, head, body, callback) {
+        callback(null, {
+            ok: true,
+            head: head,
+            body: body
+        });
+    }
+
+    server.listen(9999, '127.0.0.1', onListening);
+
+    function onListening() {
+        var clientChan = client.makeSubChannel({
+            serviceName: 'server',
+            peers: [server.hostPort]
+        });
+        tchannelJSON.send(clientChan.request({
+            headers: {
+                cn: 'client'
+            },
+            serviceName: 'server',
+            hasNoParent: true
+        }), 'echo', {
+            head: 'object'
+        }, {
+            body: 'object'
+        }, onResponse);
+
+        function onResponse(err, resp) {
+            if (err) {
+                console.log('got error', err);
+                assert.ifError("Should not receive an err", err)
+            } else {
+                assert.equal(resp.ok, true);
+                console.log('got resp', resp);
+            }
+            assert.end();
+
+            server.close();
+            client.close();
+        }
+    }
+});

--- a/test/trace/basic_thrift_server.js
+++ b/test/trace/basic_thrift_server.js
@@ -1,0 +1,108 @@
+// Copyright (c) 2016 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+var fs = require('fs');
+var path = require('path');
+
+var DebugLogtron = require('debug-logtron');
+var test = require('tape');
+
+var TChannel = require('../../channel.js');
+var TChannelAsThrift = require('../../as/thrift');
+
+var openTracing = require('opentracing');
+var logger = DebugLogtron('tchannel');
+
+test('basic thrift tracing test', function (assert) {
+
+    var spans = [];
+
+    var oTracer = openTracing;
+
+    function traceReporter(span) {
+        spans.push(span);
+        logger.debug(span.toString());
+    }
+
+    var server = TChannel({
+        serviceName: 'server',
+        logger: logger,
+        traceReporter: traceReporter,
+        traceSample: 1,
+        trace: true,
+        openTracer: oTracer
+    });
+    var client = TChannel({
+        logger: logger,
+        traceReporter: traceReporter,
+        traceSample: 1,
+        trace: true,
+        openTracer: oTracer
+    });
+
+    var echoChannel = client.makeSubChannel({
+        serviceName: 'echo',
+        peers: ['127.0.0.1:4040']
+    });
+    var thriftPath = path.join(__dirname, '../anechoic-chamber.thrift');
+    var tchannelThrift = TChannelAsThrift({
+        channel: echoChannel,
+        entryPoint: thriftPath
+    });
+
+
+    var context = {};
+    tchannelThrift.register(server, 'Chamber::echo', context, echo);
+    function echo(context, req, head, body, callback) {
+        callback(null, {
+            ok: true,
+            head: head,
+            body: body.value
+        });
+    }
+
+    server.listen(4040, '127.0.0.1', onListening);
+    function onListening() {
+        var outHead = {};
+        tchannelThrift.send(echoChannel.request({
+            serviceName: 'server',
+            headers: {
+                cn: 'echo'
+            },
+            hasNoParent: true
+        }), 'Chamber::echo', outHead, {
+            value: 10
+        }, function onResponse(err, res) {
+            if (err) {
+                assert.ifError(err);
+            } else {
+                assert.ok(res.ok);
+                assert.equal(res.headers.as, 'thrift');
+                assert.notEqual(res.headers.as, 'echo');
+                assert.equal(res.body, 10);
+            }
+            assert.end();
+
+            server.close();
+            client.close();
+
+        });
+    }
+});

--- a/trace/agent.js
+++ b/trace/agent.js
@@ -22,6 +22,7 @@
 
 var Span = require('./span');
 var errors = require('../errors.js');
+var openTracing = require('opentracing');
 
 module.exports = Agent;
 
@@ -42,6 +43,8 @@ function Agent(options) {
     if (options.reporter) {
         this.reporter = options.reporter;
     }
+
+    this.openTracer = options.openTracer || openTracing;
 }
 
 function compareTracingIds(id1, id2) {


### PR DESCRIPTION
adding a subTracer in the tracer object in channel called openTracer. This means each request needs to have a secondary span object that's called openSpan.

This diff is to define the cut-points for openTracer without removing any parts of the old style tracing.

Still pending:
1. Proper creation of spans given the head k,v map.
2. New tests for thrift and json tracing.
