### PR TITLE
Fixup benchmarks Makefile to work out of box.

### DIFF
--- a/benchmarks/Makefile
+++ b/benchmarks/Makefile
@@ -8,7 +8,7 @@ torch-client-only-bench:
 
 torch-server-bench:
 	node index.js --relay --torch server --torchFile ./flame.raw --torchTime 10 \
-		-- --relay --skipPing -s 4096,16384 -p 1000,10000
+		-- --relay --skipPing -s 4096,16384 -p 1000
 
 torch-relay-bench:
 	node index.js --relay --torch relay --torchFile ./flame.raw --torchTime 10 \
@@ -16,7 +16,7 @@ torch-relay-bench:
 
 flame-torch-relay-bench:
 	node index.js --relay --torch relay --torchFile ./flame.html --torchTime 10 --torchType flame \
-		-- --relay --skipPing -s 4096,16384 -p 1000,10000
+		-- --relay --skipPing -s 4096,16384 -p 1000
 
 # torch-trace-bench:
 # 	node index.js --trace --relay --torch server --torchFile ./flame.raw \
@@ -35,12 +35,12 @@ top-benchmark:
 
 take:
 	node index.js --noEndpointOverhead -o $$(git rev-parse --short HEAD).json -- \
-		-m 5 -s 4,4096,16384 -p 1000,10000
+		-m 5 -s 4,4096,16384 -p 1000
 	ln -sf $$(git rev-parse --short HEAD).json $$(basename $$(git symbolic-ref HEAD)).json
 
 take_relay:
 	node index.js --relay --noEndpointOverhead -o relay-$$(git rev-parse --short HEAD).json \
-		-- --relay --skipPing -m 3 -s 4096,16384 -p 1000,10000
+		-- --relay --skipPing -m 3 -s 4096,16384 -p 1000
 	ln -sf relay-$$(git rev-parse --short HEAD).json relay-$$(basename $$(git symbolic-ref HEAD)).json
 
 take_trace:

--- a/benchmarks/Makefile
+++ b/benchmarks/Makefile
@@ -47,7 +47,7 @@ take_trace:
 	# Cannot take --trace flag to multi_bench due to timeout+OOM.
 	# Cannot take 20k concurrency as it totally falls over
 	node index.js --relay --trace --noEndpointOverhead -o trace-$$(git rev-parse --short HEAD).json \
-		-- --relay -m 5 -c 10 -s 4096,16384 -p 1000,10000
+		-- --relay -m 5 -c 10 -s 4096,16384 -p 1000 -r 10000
 	ln -sf trace-$$(git rev-parse --short HEAD).json trace-$$(basename $$(git symbolic-ref HEAD)).json
 
 .PHONY: kill-dead-benchmarks top-benchmark take take_relay take_trace

--- a/benchmarks/Makefile
+++ b/benchmarks/Makefile
@@ -8,7 +8,7 @@ torch-client-only-bench:
 
 torch-server-bench:
 	node index.js --relay --torch server --torchFile ./flame.raw --torchTime 10 \
-		-- --relay --skipPing -s 4096,16384 -p 1000,10000,20000
+		-- --relay --skipPing -s 4096,16384 -p 1000,10000
 
 torch-relay-bench:
 	node index.js --relay --torch relay --torchFile ./flame.raw --torchTime 10 \
@@ -16,7 +16,7 @@ torch-relay-bench:
 
 flame-torch-relay-bench:
 	node index.js --relay --torch relay --torchFile ./flame.html --torchTime 10 --torchType flame \
-		-- --relay --skipPing -s 4096,16384 -p 1000,10000,20000
+		-- --relay --skipPing -s 4096,16384 -p 1000,10000
 
 # torch-trace-bench:
 # 	node index.js --trace --relay --torch server --torchFile ./flame.raw \
@@ -35,12 +35,12 @@ top-benchmark:
 
 take:
 	node index.js --noEndpointOverhead -o $$(git rev-parse --short HEAD).json -- \
-		-m 5 -s 4,4096,16384 -p 1000,10000,20000
+		-m 5 -s 4,4096,16384 -p 1000,10000
 	ln -sf $$(git rev-parse --short HEAD).json $$(basename $$(git symbolic-ref HEAD)).json
 
 take_relay:
 	node index.js --relay --noEndpointOverhead -o relay-$$(git rev-parse --short HEAD).json \
-		-- --relay --skipPing -m 3 -s 4096,16384 -p 1000,10000,20000
+		-- --relay --skipPing -m 3 -s 4096,16384 -p 1000,10000
 	ln -sf relay-$$(git rev-parse --short HEAD).json relay-$$(basename $$(git symbolic-ref HEAD)).json
 
 take_trace:

--- a/benchmarks/bench_server.js
+++ b/benchmarks/bench_server.js
@@ -71,6 +71,8 @@ function BenchServer(port) {
             app: 'my-server'
         },
         trace: true,
+        logger: require('debug-logtron')('server'),
+        traceSample: argv.trace ? 1 : 0.01,
         emitConnectionMetrics: false,
         statsd: new Statsd({
             host: '127.0.0.1',
@@ -83,6 +85,7 @@ function BenchServer(port) {
     }
 
     self.serverChan = self.server.makeSubChannel({
+        traceSample: argv.trace ? 1 : 0.01,
         serviceName: 'benchmark'
     });
 

--- a/benchmarks/index.js
+++ b/benchmarks/index.js
@@ -234,7 +234,7 @@ function startRelay(type) {
         '--benchRelayPort', String(self.ports.relayServerPort),
         '--traceRelayPort', String(self.ports.relayTraceServerPort),
         '--type', type,
-        '--instances', String(self.instanceCount),
+        '--instances', type === 'trace-relay' ? '1' : String(self.instanceCount),
         self.opts.trace ? '--trace' : '--no-trace',
         self.opts.debug ? '--debug' : '--no-debug'
     ]);

--- a/benchmarks/index.js
+++ b/benchmarks/index.js
@@ -262,6 +262,7 @@ function startClient(clientPort) {
 
     var args = self.opts['--'];
     args = args.concat([
+        self.opts.trace ? '--trace' : '--no-trace',
         '--benchPort', String(self.ports.serverPort),
         '--relayServerPort', String(self.ports.relayServerPort),
         '--clientPort', String(clientPort),

--- a/benchmarks/multi_bench.js
+++ b/benchmarks/multi_bench.js
@@ -142,8 +142,10 @@ Test.prototype.newClient = function newClient(id, callback) {
         statTags: {
             app: 'my-client'
         },
+        logger: require('debug-logtron')('client'),
         emitConnectionMetrics: false,
         trace: true,
+        traceSample: argv.trace ? 1 : 0.01,
         statsd: new Statsd({
             host: '127.0.0.1',
             port: 7036
@@ -187,6 +189,7 @@ Test.prototype.newClient = function newClient(id, callback) {
     var client = clientChan.makeSubChannel({
         serviceName: 'benchmark',
         peers: peers,
+        traceSample: argv.trace ? 1 : 0.01,
         minConnections: INSTANCES > 0 ? 10 : 1
     });
     client.createTime = Date.now();

--- a/benchmarks/multi_bench.js
+++ b/benchmarks/multi_bench.js
@@ -244,11 +244,14 @@ Test.prototype.stopClients = function stopClients(callback) {
     var self = this;
 
     var count = 1;
-    this.clients.forEach(function each(client) {
-        count++;
-        (client.topChannel || client).quit(closed);
-    });
-    closed();
+
+    setTimeout(function delayCloseByFudgeFactor() {
+        self.clients.forEach(function each(client) {
+            count++;
+            (client.topChannel || client).quit(closed);
+        });
+        closed();
+    }, 1000);
 
     function closed() {
         if (--count <= 0) {

--- a/benchmarks/relay_server.js
+++ b/benchmarks/relay_server.js
@@ -28,6 +28,8 @@ var assert = require('assert');
 var TChannel = require('../channel.js');
 var RelayHandler = require('../relay_handler.js');
 
+var STATSD_PORT = 7036;
+
 var argv = readBenchConfig({
     boolean: ['trace']
 });
@@ -71,7 +73,7 @@ function RelayServer(opts) {
         trace: false,
         statsd: new Statsd({
             host: '127.0.0.1',
-            port: 7036
+            port: STATSD_PORT
         }),
         choosePeerWithHeap: true
     });

--- a/benchmarks/trace_server.js
+++ b/benchmarks/trace_server.js
@@ -26,6 +26,9 @@ process.title = 'nodejs-benchmarks-trace_server';
 var Statsd = require('uber-statsd-client');
 var Buffer = require('buffer').Buffer;
 
+var TRACE_SERVER_PORT = 7039;
+var STATSD_PORT = 7036;
+
 var TChannel = require('../channel');
 var server = TChannel({
     statTags: {
@@ -35,7 +38,7 @@ var server = TChannel({
     trace: false,
     statsd: new Statsd({
         host: '127.0.0.1',
-        port: 7036
+        port: STATSD_PORT
     })
 });
 
@@ -43,7 +46,7 @@ var tcollectorChan = server.makeSubChannel({
     serviceName: 'tcollector'
 });
 
-server.listen(7039, '127.0.0.1');
+server.listen(TRACE_SERVER_PORT, '127.0.0.1');
 
 tcollectorChan.register('TCollector::submit', function onSubmit(req, res) {
     var arg2 = new Buffer([0x00, 0x00]);


### PR DESCRIPTION
The Makefile is not configured to work out of the box.

There was also one bug in the benchmark bootstrapper that
caused the tracing benchmark to fail

I've also turned on 100% trace reporting instead of 1% for the
tracing benchmark...

So currently when benchmarking wrt to tracing:

 - `make take` will benchmark p2p, with span creation and noop-reporter
 - `make take_relay` will benchmark with relay, with span creation & noop-reporter
 - `make trace` will benchmark with relay, with span creation & 100% reporter

The four modes do the following on my laptop,

 - 6.5k @ `make take`, hand-edited to have trace: false, aka no span creation
 - 5k @ `make take`, normal, span creation, noop reporter
 - 3k @ `make take_relay`, normal, span creation, relay, noop reporter
 - 1k @ `make take_trace`, normal, span creation, relay, 100% tcollector reporter

We currently do not have a `make take_no_trace` so you have to hand edit
and s/trace: true/trace: false/.

r: @rf @oibe