### PR TITLE
handle edge case where there is no connection

### DIFF
--- a/channel.js
+++ b/channel.js
@@ -1075,9 +1075,13 @@ function sanitySweep(callback) {
         }
 
         var connection = self.serverConnections[connectionKeys[index]];
-        connection.ops.sanitySweep(function opsSweepDone() {
+        if (!connection || !connection.ops) {
             setImmediate(deferNextConn);
-        });
+        } else {
+            connection.ops.sanitySweep(function opsSweepDone() {
+                setImmediate(deferNextConn);
+            });
+        }
 
         function deferNextConn() {
             nextConn(connectionKeys, index + 1, cb);


### PR DESCRIPTION
There is an edge case where a server connection closes in
the middle of a sanity sweep. This would cause an uncaught
as that connection cannot be sweeped.

If the connection doesn't exist we just move along to the next
step in sanity sweep.

r: @rf @ssyang