### PR TITLE
Move updatePeer and drainPeer up to TChannel level

### DIFF
--- a/channel.js
+++ b/channel.js
@@ -769,7 +769,11 @@ TChannel.prototype.drainPeer = function drainPeer(peer) {
             );
         }
 
-        self.topChannel.peers.delete(peer.hostPort);
+        if (self.topChannel) {
+            self.topChannel.peers.delete(peer.hostPort);
+        } else {
+            self.peers.delete(peer.hostPort);
+        }
     }
 };
 

--- a/channel.js
+++ b/channel.js
@@ -712,6 +712,67 @@ TChannel.prototype.address = function address() {
     }
 };
 
+TChannel.prototype.updatePeers =
+function updatePeers(newPeers) {
+    // Take a snapshot of current, existing peers. This is used to delete old
+    // peers later.
+    var oldPeers = this.peers.keys().slice();
+
+    var i;
+
+    // Load new peers; duplicates are ignored
+    for (i = 0; i < newPeers.length; i++) {
+        if (typeof newPeers[i] === 'string') {
+            this.peers.add(newPeers[i]);
+        }
+    }
+
+    // Drain and delete existing peers that are not in the new peer list
+    for (i = 0; i < oldPeers.length; i++) {
+        if (newPeers.indexOf(oldPeers[i]) === -1) {
+            this.logger.info('TChannel: Removing old peer', {
+                peer: oldPeers[i]
+            });
+
+            var peer = this.peers.get(oldPeers[i]);
+            this.peers.delete(oldPeers[i]);
+
+            this.drainPeer(peer);
+        }
+    }
+
+    this.logger.info('TChannel: Loaded peers', {
+        newPeers: newPeers
+    });
+};
+
+TChannel.prototype.drainPeer = function drainPeer(peer) {
+    var self = this;
+    if (peer.draining) {
+        return;
+    }
+
+    peer.drain({
+        goal: peer.DRAIN_GOAL_CLOSE_PEER,
+        reason: 'peer has been removed from the peer list',
+        direction: 'both',
+        timeout: 5 * 1000
+    }, thenDeleteIt);
+
+    function thenDeleteIt(err) {
+        if (err) {
+            self.logger.warn(
+                'TChannel: error closing peer, deleting anyhow',
+                peer.extendLogInfo(peer.draining.extendLogInfo({
+                    error: err
+                }))
+            );
+        }
+
+        self.topChannel.peers.delete(peer.hostPort);
+    }
+};
+
 /*
     Build a new opts
     Copy all props from defaults over.

--- a/test/peer-file-watcher.js
+++ b/test/peer-file-watcher.js
@@ -73,7 +73,7 @@ allocCluster.test('changing the peer list', {
 }, function t(cluster, assert) {
     setup(cluster);
 
-    cluster.logger.whitelist('info', 'ChannelWatcher: Removing old peer');
+    cluster.logger.whitelist('info', 'TChannel: Removing old peer');
     cluster.logger.whitelist('info', 'draining peer');
 
     var firstPeers = [];


### PR DESCRIPTION
Moving `updatePeer` and `drainPeer` up to `TChannel` level so we can update without using peer file watcher.