### PR TITLE
request: checkTimeout() after identified

### DIFF
--- a/peer.js
+++ b/peer.js
@@ -56,6 +56,7 @@ function TChannelPeer(channel, hostPort, options) {
     this.deltaOutConnectionEvent = this.defineEvent('deltaOutConnection');
 
     this.channel = channel;
+    this.socketInitTimeout = channel.initTimeout;
     this.logger = this.channel.logger;
     this.timers = this.channel.timers;
     this.random = this.channel.random;
@@ -713,7 +714,9 @@ TChannelPeer.prototype.makeOutSocket = function makeOutSocket() {
 TChannelPeer.prototype.makeOutConnection = function makeOutConnection(socket) {
     var self = this;
     var chan = self.channel.topChannel || self.channel;
-    var conn = new TChannelConnection(chan, socket, 'out', self.hostPort);
+    var conn = new TChannelConnection(
+        chan, socket, 'out', self.hostPort, this.socketInitTimeout
+    );
     self.allocConnectionEvent.emit(self, conn);
     return conn;
 };

--- a/request.js
+++ b/request.js
@@ -328,6 +328,11 @@ TChannelRequest.prototype.resend = function resend() {
 
 TChannelRequest.prototype.onIdentified = function onIdentified(peer) {
     var self = this;
+
+    if (self.checkTimeout()) {
+        return;
+    }
+
     var opts = {};
     var keys = Object.keys(self.options);
     for (var i = 0; i < keys.length; i++) {

--- a/sub_peers.js
+++ b/sub_peers.js
@@ -35,6 +35,7 @@ function TChannelSubPeers(channel, options) {
     var self = this;
     this.peerScoreThreshold = this.options.peerScoreThreshold || 0;
     this.choosePeerWithHeap = channel.choosePeerWithHeap;
+    this.socketInitTimeout = channel.initTimeout;
 
     this.hasMinConnections = typeof options.minConnections === 'number';
     this.minConnections = options.minConnections;
@@ -118,6 +119,7 @@ TChannelSubPeers.prototype.add = function add(hostPort, options) {
 
     peer = topChannel.peers.add(hostPort, options);
     peer.setPreferConnectionDirection(self.preferConnectionDirection);
+    peer.socketInitTimeout = this.socketInitTimeout;
 
     if (peer.countConnections('out') > 0) {
         this.currentConnectedPeers++;

--- a/test/relay-to-dead.js
+++ b/test/relay-to-dead.js
@@ -43,7 +43,8 @@ allocCluster.test('relaying to init timeout server', {
 
         var relayChan = relay.makeSubChannel({
             serviceName: 'dead-service',
-            peers: [deadHostPort]
+            peers: [deadHostPort],
+            initTimeout: 250
         });
         relayChan.handler = new RelayHandler(relayChan);
 

--- a/test/timeouts.js
+++ b/test/timeouts.js
@@ -158,7 +158,7 @@ allocCluster.test('requests will timeout even for slow conn', {
                 'as': 'raw',
                 cn: 'wat'
             },
-            timeout: 500
+            timeout: 450
         })
         .send('/normal-proxy', 'h', 'b', onResp);
 
@@ -188,7 +188,7 @@ allocCluster.test('requests will timeout even for slow conn', {
                     'as': 'raw',
                     cn: 'wat'
                 },
-                timeout: 500
+                timeout: 450
             })
             .send('/slow-proxy', 'h', 'b', onTimeout);
     }
@@ -226,6 +226,129 @@ allocCluster.test('requests will timeout even for slow conn', {
             res.headers.as = 'raw';
             res.sendOk(arg2, arg3);
         }, 650);
+    }
+});
+
+allocCluster.test('requests will timeout with custom init timeout', {
+    numPeers: 3
+}, function t(cluster, assert) {
+    var one = cluster.channels[0];
+    var two = cluster.channels[1];
+    var three = cluster.channels[2];
+
+    cluster.logger.whitelist(
+        'info', 'error for timed out outgoing response'
+    );
+    cluster.logger.whitelist(
+        'info', 'ignoring outresponse.send on a closed connection'
+    );
+    cluster.logger.whitelist(
+        'info', 'OutResponse.send() after inreq timed out'
+    );
+    cluster.logger.whitelist(
+        'warn', ' Got a connection error'
+    );
+    cluster.logger.whitelist(
+        'warn', 'destroying due to init timeout'
+    );
+    cluster.logger.whitelist(
+        'warn', 'resetting connection'
+    );
+    cluster.logger.whitelist('warn', 'Got a connection error');
+
+    // server
+    var sub = one.makeSubChannel({
+        serviceName: 'server'
+    });
+    sub.register('/normal-proxy', normalProxy);
+
+    one.connectionEvent.on(function onConnectionEvent(conn) {
+        var socket = conn.socket;
+
+        socket.pause();
+        setTimeout(function delaySocket() {
+            socket.resume();
+        }, 1000);
+    });
+
+    // client
+    var twoSub = two.makeSubChannel({
+        serviceName: 'server',
+        peers: [one.hostPort]
+    });
+    var start = 0;
+
+    // make normal request
+    twoSub
+        .request({
+            serviceName: 'server',
+            hasNoParent: true,
+            headers: {
+                'as': 'raw',
+                cn: 'wat'
+            },
+            timeout: 2000
+        })
+        .send('/normal-proxy', 'h', 'b', onResp);
+
+    function onResp(err, res, arg2, arg3) {
+        assert.ifError(err);
+
+        assert.equal(String(arg2), 'h');
+        assert.equal(String(arg3), 'b');
+
+        doSecond();
+    }
+
+    function doSecond() {
+        // another client
+        var threeSub = three.makeSubChannel({
+            serviceName: 'server',
+            peers: [one.hostPort],
+            initTimeout: 500
+        });
+
+        start = Date.now();
+        // slow request
+        threeSub
+            .request({
+                serviceName: 'server',
+                hasNoParent: true,
+                headers: {
+                    'as': 'raw',
+                    cn: 'wat'
+                },
+                timeout: 2000
+            })
+            .send('/normal-proxy', 'h', 'b', onTimeout);
+    }
+
+    function onTimeout(err, res, arg2, arg3) {
+        assert.ok(
+            (err && err.type) === 'tchannel.connection.timeout',
+            'expected timeout error'
+        );
+
+        var delta = Date.now() - start;
+
+        if (typeof err.elapsed === 'number') {
+            assert.ok(err.elapsed < 600, 'expected timeout within 600ms');
+        }
+        assert.ok(delta < 600, 'expected timeout within 600ms');
+
+        if (delta > 600) {
+            console.log('d', delta);
+        }
+
+        setTimeout(function delay() {
+            cluster.assertEmptyState(assert);
+            assert.end();
+        }, 500);
+    }
+
+    function normalProxy(req, res, arg2, arg3) {
+        res.headers.as = 'raw';
+        res.sendOk(arg2, arg3);
     }
 });
 

--- a/test/timeouts.js
+++ b/test/timeouts.js
@@ -305,7 +305,7 @@ allocCluster.test('requests will timeout with custom init timeout', {
         var threeSub = three.makeSubChannel({
             serviceName: 'server',
             peers: [one.hostPort],
-            initTimeout: 500
+            initTimeout: 450
         });
 
         start = Date.now();
@@ -335,8 +335,7 @@ allocCluster.test('requests will timeout with custom init timeout', {
             assert.ok(err.elapsed < 600, 'expected timeout within 600ms');
         }
         assert.ok(delta < 600, 'expected timeout within 600ms');
-
-        if (delta > 600) {
+        if (delta >= 600) {
             console.log('d', delta);
         }
 

--- a/test/timeouts.js
+++ b/test/timeouts.js
@@ -21,6 +21,8 @@
 'use strict';
 
 var TimeMock = require('time-mock');
+var setTimeout = require('timers').setTimeout;
+
 var allocCluster = require('./lib/alloc-cluster.js');
 var timers = TimeMock(Date.now());
 
@@ -104,6 +106,126 @@ allocCluster.test('requests will timeout', {
     }
     function timeout(/* head, body, hostInfo, cb */) {
         // do not call cb();
+    }
+});
+
+allocCluster.test('requests will timeout even for slow conn', {
+    numPeers: 3
+}, function t(cluster, assert) {
+    var one = cluster.channels[0];
+    var two = cluster.channels[1];
+    var three = cluster.channels[2];
+
+    cluster.logger.whitelist(
+        'info', 'error for timed out outgoing response'
+    );
+    cluster.logger.whitelist(
+        'info', 'ignoring outresponse.send on a closed connection'
+    );
+    cluster.logger.whitelist(
+        'info', 'OutResponse.send() after inreq timed out'
+    );
+
+    // server
+    var sub = one.makeSubChannel({
+        serviceName: 'server'
+    });
+    sub.register('/normal-proxy', normalProxy);
+    sub.register('/slow-proxy', slowProxy);
+
+    one.connectionEvent.on(function onConnectionEvent(conn) {
+        var socket = conn.socket;
+
+        socket.pause();
+        setTimeout(function delaySocket() {
+            socket.resume();
+        }, 300);
+    });
+
+    // client
+    var twoSub = two.makeSubChannel({
+        serviceName: 'server',
+        peers: [one.hostPort]
+    });
+    var start = 0;
+
+    // make normal request
+    twoSub
+        .request({
+            serviceName: 'server',
+            hasNoParent: true,
+            headers: {
+                'as': 'raw',
+                cn: 'wat'
+            },
+            timeout: 500
+        })
+        .send('/normal-proxy', 'h', 'b', onResp);
+
+    function onResp(err, res, arg2, arg3) {
+        assert.ifError(err);
+
+        assert.equal(String(arg2), 'h');
+        assert.equal(String(arg3), 'b');
+
+        doSecond();
+    }
+
+    function doSecond() {
+        // another client
+        var threeSub = three.makeSubChannel({
+            serviceName: 'server',
+            peers: [one.hostPort]
+        });
+
+        // slow request
+        start = Date.now();
+        threeSub
+            .request({
+                serviceName: 'server',
+                hasNoParent: true,
+                headers: {
+                    'as': 'raw',
+                    cn: 'wat'
+                },
+                timeout: 500
+            })
+            .send('/slow-proxy', 'h', 'b', onTimeout);
+    }
+
+    function onTimeout(err) {
+        assert.ok(
+            (err && err.type) === 'tchannel.request.timeout' ||
+            (err && err.type) === 'tchannel.timeout',
+            'expected timeout error'
+        );
+
+        var delta = Date.now() - start;
+
+        if (typeof err.elapsed === 'number') {
+            assert.ok(err.elapsed < 600, 'expected timeout within 600ms');
+        }
+        assert.ok(delta < 600, 'expected timeout within 600ms');
+
+        if (delta > 600) {
+            console.log('d', delta);
+        }
+
+        setTimeout(function delay() {
+            cluster.assertEmptyState(assert);
+            assert.end();
+        }, 500);
+    }
+
+    function normalProxy(req, res, arg2, arg3) {
+        res.headers.as = 'raw';
+        res.sendOk(arg2, arg3);
+    }
+    function slowProxy(req, res, arg2, arg3) {
+        setTimeout(function respond() {
+            res.headers.as = 'raw';
+            res.sendOk(arg2, arg3);
+        }, 650);
     }
 });
 
@@ -266,12 +388,12 @@ allocCluster.test('requests can succeed after timeout per attempt', {
         assert.end();
     }
 
-    function normalProxy(req, res, arg2, arg3) {
+    function normalProxy(req2, res, arg2, arg3) {
         res.headers.as = 'raw';
         res.sendOk(arg2, arg3);
     }
     var count = 0;
-    function timeout(req, res, arg2, arg3) {
+    function timeout(req2, res, arg2, arg3) {
         count++;
         if (count === 2) {
             res.headers.as = 'raw';


### PR DESCRIPTION
We need to do another checkTimeout() after the request
is identified to double check that we did not consume our
request budget in the connection init handshake.

We also need to update the `elapsed` time so that when we
make our outbound request we set a proper `ttl-elapsed` timeout
on the per attempt request.

r: @zhijin @syyang