### PR TITLE
ensure that requests timeout even when initOp

### DIFF
--- a/request.js
+++ b/request.js
@@ -84,13 +84,13 @@ function RequestOperation(req, timeout, peer, waitForIdentifiedSlot) {
     this.req = req;
     this.timeout = timeout;
     this.peer = peer;
-    this.waitForIdentifiedSlot = waitForIdentifiedSlot;
+    this.waitForIdentifiedSlot =
+        typeof waitForIdentifiedSlot === 'number' ?
+        waitForIdentifiedSlot : -1;
 }
 
 RequestOperation.prototype.onTimeout = function onTimeout(now) {
-    if (this.waitForIdentifiedSlot !== null &&
-        this.waitForIdentifiedSlot !== -1
-    ) {
+    if (this.waitForIdentifiedSlot !== -1) {
         this.peer.stopWaitingForIdentified(this.waitForIdentifiedSlot);
     }
 

--- a/request.js
+++ b/request.js
@@ -80,6 +80,23 @@ inherits(TChannelRequest, EventEmitter);
 TChannelRequest.defaultRetryLimit = 5;
 TChannelRequest.defaultTimeout = 100;
 
+function RequestOperation(req, timeout, peer, waitForIdentifiedSlot) {
+    this.req = req;
+    this.timeout = timeout;
+    this.peer = peer;
+    this.waitForIdentifiedSlot = waitForIdentifiedSlot;
+}
+
+RequestOperation.prototype.onTimeout = function onTimeout(now) {
+    if (this.waitForIdentifiedSlot !== null &&
+        this.waitForIdentifiedSlot !== -1
+    ) {
+        this.peer.stopWaitingForIdentified(this.waitForIdentifiedSlot);
+    }
+
+    this.req.checkTimeout();
+};
+
 TChannelRequest.prototype.type = 'tchannel.request';
 
 TChannelRequest.prototype.emitError = function emitError(err) {
@@ -304,9 +321,25 @@ TChannelRequest.prototype.resend = function resend() {
         return;
     }
 
-    peer.waitForIdentified(onIdentified);
+    var conn = peer.getInConnection(true);
+    var reqTimeout;
+    if (conn && conn.remoteName && !conn.closing) {
+        self.onIdentified(peer);
+    } else {
+        var waitForIdentifiedSlot = peer.waitForIdentified(onIdentified);
+
+        var now = self.channel.timers.now();
+        self.elapsed = now - self.start;
+        var timeout = self.timeout - self.elapsed;
+        var reqOp = new RequestOperation(
+            self, timeout, peer, waitForIdentifiedSlot
+        );
+        reqTimeout = self.channel.timeHeap.update(reqOp, now);
+    }
 
     function onIdentified(err) {
+        reqTimeout.cancel();
+
         if (err) {
             /* emulate outReq failure */
 

--- a/test/timeouts.js
+++ b/test/timeouts.js
@@ -435,6 +435,127 @@ allocCluster.test('requests will timeout per attempt', {
     }
 });
 
+allocCluster.test('requests will timeout exactly with slow conn', {
+    numPeers: 3
+}, function t(cluster, assert) {
+    var one = cluster.channels[0];
+    var two = cluster.channels[1];
+    var three = cluster.channels[2];
+
+    cluster.logger.whitelist(
+        'info', 'error for timed out outgoing response'
+    );
+    cluster.logger.whitelist(
+        'info', 'ignoring outresponse.send on a closed connection'
+    );
+    cluster.logger.whitelist(
+        'info', 'OutResponse.send() after inreq timed out'
+    );
+    cluster.logger.whitelist(
+        'warn', ' Got a connection error'
+    );
+    cluster.logger.whitelist(
+        'warn', 'destroying due to init timeout'
+    );
+    cluster.logger.whitelist(
+        'warn', 'resetting connection'
+    );
+    cluster.logger.whitelist('warn', 'Got a connection error');
+
+    // server
+    var sub = one.makeSubChannel({
+        serviceName: 'server'
+    });
+    sub.register('/normal-proxy', normalProxy);
+
+    one.connectionEvent.on(function onConnectionEvent(conn) {
+        var socket = conn.socket;
+
+        socket.pause();
+        setTimeout(function delaySocket() {
+            socket.resume();
+        }, 1000);
+    });
+
+    // client
+    var twoSub = two.makeSubChannel({
+        serviceName: 'server',
+        peers: [one.hostPort]
+    });
+    var start = 0;
+
+    // make normal request
+    twoSub
+        .request({
+            serviceName: 'server',
+            hasNoParent: true,
+            headers: {
+                'as': 'raw',
+                cn: 'wat'
+            },
+            timeout: 2000
+        })
+        .send('/normal-proxy', 'h', 'b', onResp);
+
+    function onResp(err, res, arg2, arg3) {
+        assert.ifError(err);
+
+        assert.equal(String(arg2), 'h');
+        assert.equal(String(arg3), 'b');
+
+        doSecond();
+    }
+
+    function doSecond() {
+        // another client
+        var threeSub = three.makeSubChannel({
+            serviceName: 'server',
+            peers: [one.hostPort]
+        });
+
+        start = Date.now();
+        // slow request
+        threeSub
+            .request({
+                serviceName: 'server',
+                hasNoParent: true,
+                headers: {
+                    'as': 'raw',
+                    cn: 'wat'
+                },
+                timeout: 450
+            })
+            .send('/normal-proxy', 'h', 'b', onTimeout);
+    }
+
+    function onTimeout(err, res, arg2, arg3) {
+        assert.ok(
+            (err && err.type) === 'tchannel.request.timeout',
+            'expected timeout error'
+        );
+
+        var delta = Date.now() - start;
+
+        if (typeof err.elapsed === 'number') {
+            assert.ok(err.elapsed < 600, 'expected timeout within 600ms');
+        }
+        assert.ok(delta < 600, 'expected timeout within 600ms');
+        if (delta >= 600) {
+            console.log('d', delta);
+        }
+
+        setTimeout(function delay() {
+            cluster.assertEmptyState(assert);
+            assert.end();
+        }, 500);
+    }
+
+    function normalProxy(req, res, arg2, arg3) {
+        res.headers.as = 'raw';
+        res.sendOk(arg2, arg3);
+    }
+});
+
 allocCluster.test('requests can succeed after timeout per attempt', {
     numPeers: 3,
     channelOptions: {


### PR DESCRIPTION
This improves the pre-flight waitForIdentified() logic
in the tchannel.Request class.

Here we will actually do a check to see if we have
a usable connection and skip the waiting.

If we have to wait because there are zero connections
we also allocate a RequestOperation with a properly
configured timeout and add it to the timeHeap.

This means that the request will timeout within it's
specified `timeout` irregardless of what the connection
initTimeout value is.

We clean up and cancel the timeout once a connection
is identified and available

r: @zhijin @syyang