### PR TITLE
peer: handle edge case where identified descriptor is null

### DIFF
--- a/peer.js
+++ b/peer.js
@@ -555,6 +555,11 @@ function stopWaitingForIdentified(slot) {
 
     var descriptor = this.waitForIdentifiedListeners[slot];
     this.waitForIdentifiedListeners[slot] = null;
+
+    if (!descriptor || !descriptor.conn) {
+        return;
+    }
+
     var conn = descriptor.conn;
 
     conn.errorEvent.removeListener(descriptor.error);


### PR DESCRIPTION
Because of edge cases there is a race between connection
identification and timeouts.

A timeout may still fire whilst a connection has already
been estabilished.

We need a null check here and do a no-op.

r: @zhijinli @proflayton