### PR TITLE
Updated peer score strategy to not fully connect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,26 @@
+
+# v3.9.8
+
+- Improvement: Ensure that peer selection strategy does not
+    fully connect to all peers in the peer list. This will reduce
+    file descriptor usage and means each sub channel either has
+    1+(n incoming) connected peers or `minConnection` number of connected
+    peers. 
+
+# v3.9.7
+
+- Bug fix: Fix uncaught where wait for identifier is null.
+
+# v3.9.6
+
+- Bump thriftrw to 3.8.0
+
+# v3.9.4
+
+- Bug fix: Ensure that per-request timeout is respected in the
+    connection init phase
+- Bug fix: Fix uncaught exception where there are no connections 
+
 # v3.9.3
 
 - Check whether requests time out while waiting for connection identification.

--- a/peer_score_strategies.js
+++ b/peer_score_strategies.js
@@ -60,12 +60,12 @@ PreferOutgoing.prototype.getScoreRange = function getScoreRange() {
     switch (tier) {
         default:
             /* falls through */
+        case PreferOutgoing.UNCONNECTED:
+            return new Range(0.1, 0.2);
         case PreferOutgoing.ONLY_INCOMING:
             /* falls through */
-        case PreferOutgoing.UNCONNECTED:
-            /* falls through */
         case PreferOutgoing.FRESH_OUTGOING:
-            return new Range(0.1, 0.4);
+            return new Range(0.2, 0.4);
         case PreferOutgoing.READY_OUTGOING:
             return new Range(0.4, 1.0);
     }
@@ -102,9 +102,9 @@ NoPreference.prototype.getScoreRange = function getScoreRange() {
         default:
             /* falls through */
         case NoPreference.UNCONNECTED:
-            /* falls through */
+            return new Range(0.1, 0.2);
         case NoPreference.CONNECTED:
-            return new Range(0.1, 0.4);
+            return new Range(0.2, 0.4);
         case NoPreference.IDENTIFIED:
             return new Range(0.4, 1.0);
     }
@@ -144,12 +144,12 @@ PreferIncoming.prototype.getScoreRange = function getScoreRange() {
     switch (tier) {
         default:
             /* falls through */
+        case PreferIncoming.UNCONNECTED:
+            return new Range(0.1, 0.2);
         case PreferIncoming.ONLY_OUTGOING:
             /* falls through */
-        case PreferIncoming.UNCONNECTED:
-            /* falls through */
         case PreferIncoming.FRESH_INCOMING:
-            return new Range(0.1, 0.4);
+            return new Range(0.2, 0.4);
         case PreferIncoming.READY_INCOMING:
             return new Range(0.4, 1.0);
     }

--- a/peer_score_strategies.js
+++ b/peer_score_strategies.js
@@ -53,7 +53,8 @@ PreferOutgoing.prototype.getTier = function getTier() {
 
 PreferOutgoing.prototype.getScoreRange = function getScoreRange() {
     // space:
-    //   [0.1, 0.4)  peers with no identified outgoing connection
+    //   [0.1, 0.2)  peers with zero connections
+    //   [0.2, 0.4)  peers with no identified outgoing connection
     //   [0.4, 1.0)  identified outgoing connections
     var tier = this.getTier();
     this.lastTier = tier;
@@ -94,7 +95,8 @@ NoPreference.prototype.getTier = function getTier() {
 
 NoPreference.prototype.getScoreRange = function getScoreRange() {
     // space:
-    //   (0.1, 0.4]  peers with no identified connection
+    //   [0.1, 0.2)  peers with zero connections
+    //   (0.2, 0.4]  peers with no identified connection
     //   (0.4, 1.0]  identified connections
     var tier = this.getTier();
     this.lastTier = tier;
@@ -137,8 +139,9 @@ PreferIncoming.prototype.getTier = function getTier() {
 
 PreferIncoming.prototype.getScoreRange = function getScoreRange() {
     // space:
-    //   [0.1, 0.4)  peers with no identified outgoing connection
-    //   [0.4, 1.0)  identified outgoing connections
+    //   [0.1, 0.2)  peers with zero connections
+    //   [0.2, 0.4)  peers with no identified incoming connection
+    //   [0.4, 1.0)  identified incoming connections
     var tier = this.getTier();
     this.lastTier = tier;
     switch (tier) {

--- a/test/peer-to-peer-load-balance.js
+++ b/test/peer-to-peer-load-balance.js
@@ -562,8 +562,8 @@ function setup(cluster, opts) {
     for (i = 0; i < cluster.clients.length; i++) {
         cluster.batches.push(new BatchClient(
             cluster.clients[i], cluster.serverHosts, {
-                delay: 40,
-                batchSize: 1,
+                delay: 200,
+                batchSize: 2,
                 timeout: 1500,
                 totalRequests: 50,
                 minConnections: opts.minConnections || null,

--- a/test/peer-to-peer-load-balance.js
+++ b/test/peer-to-peer-load-balance.js
@@ -564,7 +564,7 @@ function setup(cluster, opts) {
             cluster.clients[i], cluster.serverHosts, {
                 delay: 40,
                 batchSize: 1,
-                timeout: 1000,
+                timeout: 1500,
                 totalRequests: 50,
                 minConnections: opts.minConnections || null,
                 retryLimit: opts.retryLimit || null


### PR DESCRIPTION
This updates the peer selection score strategy to mark
unconnected peers as the lowest score.

This means that we will not fully connect and will
in general use 1 peer most of the time.

The only time more then 1 peer is used per sub channel:

 - minConnections is configured for p2p
 - hyperbahn is used and extra inbound peers are estabilished.

r: @kriskowal @prashantv @jialiehu