### PR TITLE
Handle undefined as default value in thrift result structs

### DIFF
--- a/as/thrift.js
+++ b/as/thrift.js
@@ -561,7 +561,7 @@ function thriftIDL(tchannelThrift, req, head, body, callback) {
 // TODO proper Thriftify result union that reifies as the selected field.
 function onlyKey(object) {
     for (var name in object) {
-        if (object[name] !== null) {
+        if (object[name] != null) {
             return name;
         }
     }

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "safe-json-parse": "^4.0.0",
     "sse4_crc32": "4.1.1",
     "tape-cluster": "2.1.0",
-    "thriftrw": "^3.10.0",
+    "thriftrw": "^3.11.0",
     "xorshift": "^0.2.0",
     "xtend": "^4.0.0"
   },


### PR DESCRIPTION
There was logic that attempted to retrieve the set exception from the method response struct. However, it made the assumption that the default value would always be null. In this case, with undefined as the default value, the user would get returned any of the error values (leading sometimes to undefined error responses).

Accept null or undefined values on the response structs. Ideally we should treat the the exception response as a union and have some convenience methods to fetch the value