### PR TITLE
Expressly depend on binary dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,14 +2,6 @@ language: node_js
 
 jobs:
   include:
-    - node_js: "12"
-      env: CXX=g++-4.8 TCHANNEL_TEST_CONFIG= NPM_TEST_SCRIPT=travis
-    - node_js: "5"
-      env: CXX=g++-4.8 TCHANNEL_TEST_CONFIG= NPM_TEST_SCRIPT=travis
-    - node_js: "4"
-      env: CXX=g++-4.8 TCHANNEL_TEST_CONFIG= NPM_TEST_SCRIPT=travis
-    - node_js: "3"
-      env: CXX=g++-4.8 TCHANNEL_TEST_CONFIG= NPM_TEST_SCRIPT=travis
     - node_js: "0.10"
       env: CXX=g++-4.8 TCHANNEL_TEST_CONFIG= NPM_TEST_SCRIPT=travis
     # - node_js: "0.10"

--- a/package.json
+++ b/package.json
@@ -4,7 +4,6 @@
   "author": "mranney@uber.com",
   "version": "3.10.0",
   "scripts": {
-    "postinstall": "bash scripts/postinstall.sh",
     "lint": "eslint $(git ls-files | grep '.js$')",
     "travis": "npm run check-licence && npm run lint -s && npm run travis-cover -s && npm run check-benchmark -s",
     "test": "npm run check-licence && npm run lint -s && npm run cover -s && npm run check-benchmark -s",
@@ -34,6 +33,8 @@
     "bufrw": "^1.2.1",
     "crc": "^3.8.0",
     "error": "^7.0.1",
+    "farmhash": "^1",
+    "sse4_crc32": "^5",
     "json-stringify-safe": "^5.0.0",
     "metrics": "^0.1.8",
     "minimist": "^1.1.0",

--- a/scripts/postinstall.sh
+++ b/scripts/postinstall.sh
@@ -1,5 +1,0 @@
-#!/bin/bash
-set -ueo pipefail
-npm install --no-save \
-    "farmhash@^$(node -e 'console.log(/v(\d+)\./.exec(process.version)[1] >= 4 ? 3 : 1)')" \
-    "sse4_crc32@^$(node -e 'console.log(/v(\d+)\./.exec(process.version)[1] >= 4 ? 6 : 5)')"


### PR DESCRIPTION
This change removes the postinstall hook and replaces it with express dependencies on farmhash and sse4-crc32. This change targets the v3 release train and will not land on master.