### PR TITLE
Enable timeHeap configuration.

### DIFF
--- a/channel.js
+++ b/channel.js
@@ -615,7 +615,7 @@ TChannel.prototype.makeSubChannel = function makeSubChannel(options) {
     }
 
     opts.topChannel = self;
-    opts.timeHeap = self.timeHeap;
+    opts.timeHeap = options.timeHeap || self.timeHeap;
 
     opts.enableMaxRetryRatio = options.enableMaxRetryRatio;
     opts.maxRetryRatio = options.maxRetryRatio;


### PR DESCRIPTION
Currently sub-channel depends on the global time-heap and this will increase the min-heap array size which is used to track the timers. In order to reduce the min heap array size, sub-channel can pass down the timeHeap from the opts. 