### PR TITLE
Remove exclusion of 0.0.0.0 as invalid ip address

### DIFF
--- a/host-port.js
+++ b/host-port.js
@@ -26,17 +26,13 @@ module.exports.validateHostPort = validateHostPort;
 module.exports.validateHost = validateHost;
 module.exports.validatePort = validatePort;
 
-function validateHost(host, allowEmphemeral) {
+function validateHost(host) {
     if (typeof host !== 'string') {
         return 'Expected host to be a string';
     }
 
     if (!validIPv4.test(host)) {
         return 'Expected host to contain IPv4';
-    }
-
-    if (!allowEmphemeral && host === '0.0.0.0') {
-        return 'Expected host to not be 0.0.0.0';
     }
 
     return null;


### PR DESCRIPTION
The exclusion of 0.0.0.0 blocks the ability to refer to localhost ip the way it is done on nodejs's idiom of not requiring the server's hostname to be explicitly defined.  